### PR TITLE
refactor rust internals

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -117,7 +117,7 @@ fn run() -> Result<()> {
             let (at, existing, missing_marker) = init_target(&manager, &requested, here)?;
             let initialized_from_inside = std::env::current_dir()?.starts_with(&at);
             let mut converting = false;
-            let converted = manager.init_with_progress(&at, |progress| match progress {
+            let outcome = manager.init_with_progress(&at, |progress| match progress {
                 InitProgress::CreatingSubvolume => {
                     converting = true;
                     eprintln!("Initializing  {}\n", at.display());
@@ -132,7 +132,7 @@ fn run() -> Result<()> {
                 | InitProgress::RestoringMarker
                 | InitProgress::RemovingOriginal => {}
             })?;
-            if converted {
+            if outcome.is_converted() {
                 if converting {
                     eprintln!("\nReady  {}", at.display());
                 } else {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -96,16 +96,22 @@ fn error_message(error: &rift::Error) -> String {
 
 fn run() -> Result<()> {
     let cli = Cli::parse();
-    if let Command::ShellInit { shell } = &cli.command {
-        print_shell_init(*shell);
-        return Ok(());
-    }
+    let command = match cli.command {
+        Command::ShellInit { shell } => {
+            print_shell_init(shell);
+            return Ok(());
+        }
+        command => command,
+    };
     let mut manager = match cli.database {
         Some(path) => Manager::open(path)?,
         None => Manager::open_default()?,
     };
-    match cli.command {
-        Command::ShellInit { .. } => unreachable!(),
+    match command {
+        Command::ShellInit { shell } => {
+            print_shell_init(shell);
+            Ok(())
+        }
         Command::Init { at, here } => {
             let requested = std::fs::canonicalize(at.unwrap_or(std::env::current_dir()?))?;
             let (at, existing, missing_marker) = init_target(&manager, &requested, here)?;
@@ -149,6 +155,7 @@ fn run() -> Result<()> {
             } else {
                 eprintln!("Ready  {}", at.display());
             }
+            Ok(())
         }
         Command::Create { from, name, into } => {
             let destination = manager.create(Create {
@@ -160,6 +167,7 @@ fn run() -> Result<()> {
                 eprintln!("created {}", destination.display());
             }
             println!("{}", destination.display());
+            Ok(())
         }
         Command::Remove {
             at,
@@ -206,24 +214,27 @@ fn run() -> Result<()> {
                     }
                 }
             }
+            Ok(())
         }
         Command::List { of } => {
             for path in manager.list(of.unwrap_or(std::env::current_dir()?))? {
                 println!("{}", path.display());
             }
+            Ok(())
         }
         Command::Ancestors { of } => {
             for path in manager.ancestors(of.unwrap_or(std::env::current_dir()?))? {
                 println!("{}", path.display());
             }
+            Ok(())
         }
         Command::Gc => {
             for path in manager.gc()? {
                 println!("{}", path.display());
             }
+            Ok(())
         }
     }
-    Ok(())
 }
 
 fn init_target(

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -35,10 +35,10 @@ pub(crate) fn hide_marker(path: &Path) -> Result<()> {
     let info = path.join(".git").join("info");
     fs::create_dir_all(&info)?;
     let exclude = info.join("exclude");
-    let existing = if exclude.exists() {
-        fs::read_to_string(&exclude)?
-    } else {
-        String::new()
+    let existing = match fs::read_to_string(&exclude) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error.into()),
     };
     if existing.lines().any(|line| line.trim() == "/.rift") {
         return Ok(());

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -3,10 +3,22 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-pub(crate) fn check_source(path: &Path) -> Result<bool> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Source {
+    PlainDirectory,
+    Repository,
+}
+
+impl Source {
+    pub(crate) fn is_repository(self) -> bool {
+        matches!(self, Self::Repository)
+    }
+}
+
+pub(crate) fn check_source(path: &Path) -> Result<Source> {
     let git = path.join(".git");
     if !git.exists() {
-        return Ok(false);
+        return Ok(Source::PlainDirectory);
     }
     if !git.is_dir() {
         return Err(Error::UnsafeGit(
@@ -28,7 +40,7 @@ pub(crate) fn check_source(path: &Path) -> Result<bool> {
             return Err(Error::UnsafeGit(format!("Git state in progress: {state}")));
         }
     }
-    Ok(true)
+    Ok(Source::Repository)
 }
 
 pub(crate) fn hide_marker(path: &Path) -> Result<()> {
@@ -80,6 +92,16 @@ mod tests {
             check_source(temp.path()),
             Err(Error::UnsafeGit(_))
         ));
+    }
+
+    #[test]
+    fn check_source_distinguishes_plain_and_git_directories() {
+        let plain = TempDir::new().unwrap();
+        assert_eq!(check_source(plain.path()).unwrap(), Source::PlainDirectory);
+
+        let git = TempDir::new().unwrap();
+        fs::create_dir(git.path().join(".git")).unwrap();
+        assert_eq!(check_source(git.path()).unwrap(), Source::Repository);
     }
 
     #[test]

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -1,0 +1,25 @@
+use std::fmt;
+use ulid::Ulid;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct RiftId(String);
+
+impl RiftId {
+    pub(crate) fn new() -> Self {
+        Self(Ulid::new().to_string())
+    }
+
+    pub(crate) fn from_stored(value: String) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RiftId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,13 +1,17 @@
 mod git;
+mod id;
+mod marker;
+mod name;
+mod registry;
 mod strategy;
 
-use rand::Rng;
-use rusqlite::{Connection, OptionalExtension, params};
+use id::RiftId;
+use name::RiftName;
+use registry::{MovedRecord, PathRecord, Record, Registry, SubtreeScope};
 use std::fs;
 use std::path::{Path, PathBuf};
 use strategy::{Strategy, StrategyInit};
 use thiserror::Error;
-use ulid::Ulid;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -77,15 +81,8 @@ impl InitOutcome {
     }
 }
 
-#[derive(Clone)]
-struct Record {
-    id: String,
-    parent_id: Option<String>,
-    path: PathBuf,
-}
-
 pub struct Manager {
-    database: Connection,
+    registry: Registry,
     strategy: Box<dyn Strategy>,
 }
 
@@ -103,23 +100,8 @@ impl Manager {
     }
 
     fn with_strategy(path: impl AsRef<Path>, strategy: Box<dyn Strategy>) -> Result<Self> {
-        let database = Connection::open(path)?;
-        database.execute_batch(
-            "PRAGMA foreign_keys = ON;
-             CREATE TABLE IF NOT EXISTS rift (
-               id TEXT PRIMARY KEY,
-               parent_id TEXT REFERENCES rift(id) ON DELETE CASCADE,
-               path TEXT NOT NULL UNIQUE,
-               created_at INTEGER NOT NULL
-              );
-              CREATE INDEX IF NOT EXISTS rift_parent_id_idx ON rift(parent_id);
-              CREATE TABLE IF NOT EXISTS trash (
-                id TEXT PRIMARY KEY,
-                path TEXT NOT NULL UNIQUE,
-                removed_at INTEGER NOT NULL
-              );",
-        )?;
-        Ok(Self { database, strategy })
+        let registry = Registry::open(path)?;
+        Ok(Self { registry, strategy })
     }
 
     pub fn create(&mut self, input: Create) -> Result<PathBuf> {
@@ -128,18 +110,18 @@ impl Manager {
         let from = source.path.clone();
         let git = git::check_source(&from)?;
         let root = self.root(&source)?;
-        let id = Ulid::new().to_string();
+        let id = RiftId::new();
         let destination_parent = match input.into {
             Some(path) => absolute_path(&path)?,
             None => default_storage(&root.path)?,
         };
-        let name = destination_name(input.name)?;
-        if destination_parent.join(&name).starts_with(&from) {
-            return Err(Error::InsideSource(destination_parent.join(name)));
+        let name = RiftName::from_optional(input.name)?;
+        if destination_parent.join(name.as_str()).starts_with(&from) {
+            return Err(Error::InsideSource(destination_parent.join(name.as_str())));
         }
         fs::create_dir_all(&destination_parent)?;
         let destination_parent = fs::canonicalize(destination_parent)?;
-        let destination = destination_parent.join(name);
+        let destination = destination_parent.join(name.as_str());
         if destination.starts_with(&from) {
             return Err(Error::InsideSource(destination));
         }
@@ -155,7 +137,7 @@ impl Manager {
         }
 
         let result = (|| {
-            write_marker(&destination, &id)?;
+            marker::write(&destination, &id)?;
             if git.is_repository() {
                 git::hide_marker(&destination)?;
                 git::detach_destination(&destination)?;
@@ -163,10 +145,7 @@ impl Manager {
             if git.is_repository() {
                 git::hide_marker(&from)?;
             }
-            self.database.execute(
-                "INSERT INTO rift (id, parent_id, path, created_at) VALUES (?1, ?2, ?3, ?4)",
-                params![id, source.id, path_text(&destination)?, timestamp()],
-            )?;
+            self.registry.insert_child(&id, &source.id, &destination)?;
             Ok(destination.clone())
         })();
         if result.is_err() {
@@ -186,12 +165,12 @@ impl Manager {
     ) -> Result<InitOutcome> {
         let at = existing_directory(at.as_ref())?;
         let git = git::check_source(&at)?;
-        if let Some(record) = self.record_at_optional(&at)? {
-            if read_marker(&at)?.is_none() {
+        if let Some(record) = self.registry.record_at(&at)? {
+            if marker::read(&at)?.is_none() {
                 progress(InitProgress::RestoringMarker);
-                write_marker(&at, &record.id)?;
+                marker::write(&at, &record.id)?;
             } else {
-                verify_marker(&record)?;
+                marker::verify(&record.path, &record.id)?;
             }
             let converted = self.strategy.initialize_directory(&at, &mut progress)?;
             if git.is_repository() {
@@ -202,29 +181,26 @@ impl Manager {
                 StrategyInit::Converted => InitOutcome::Converted,
             });
         }
-        if read_marker(&at)?.is_some() {
+        if marker::read(&at)?.is_some() {
             return Err(Error::MarkerMismatch(at));
         }
 
         let converted = self.strategy.initialize_directory(&at, &mut progress)?;
         progress(InitProgress::RegisteringWorkspace);
-        let id = Ulid::new().to_string();
+        let id = RiftId::new();
         let result = (|| {
-            write_marker(&at, &id)?;
+            marker::write(&at, &id)?;
             if git.is_repository() {
                 git::hide_marker(&at)?;
             }
-            self.database.execute(
-                "INSERT INTO rift (id, parent_id, path, created_at) VALUES (?1, NULL, ?2, ?3)",
-                params![id, path_text(&at)?, timestamp()],
-            )?;
+            self.registry.insert_root(&id, &at)?;
             Ok(match converted {
                 StrategyInit::AlreadyNative => InitOutcome::Registered,
                 StrategyInit::Converted => InitOutcome::Converted,
             })
         })();
         if result.is_err() {
-            let _ = fs::remove_file(marker(&at));
+            let _ = fs::remove_file(marker::path(&at));
         }
         result
     }
@@ -234,100 +210,82 @@ impl Manager {
         if record.parent_id.is_none() {
             return self.unregister_root(&record);
         }
-        verify_marker(&record)?;
-        let rows = self.subtree(&record.id, true)?;
+        marker::verify(&record.path, &record.id)?;
+        let rows = self
+            .registry
+            .subtree(&record.id, SubtreeScope::IncludingRoot)?;
         self.trash_rows(&rows)?;
         Ok(())
     }
 
     pub fn remove_all(&mut self, at: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
         let record = self.workspace_at(at)?;
-        verify_marker(&record)?;
-        let rows = self.subtree(&record.id, false)?;
+        marker::verify(&record.path, &record.id)?;
+        let rows = self
+            .registry
+            .subtree(&record.id, SubtreeScope::DescendantsOnly)?;
         self.trash_rows(&rows)?;
-        Ok(rows.into_iter().map(|(_, path)| path).collect())
+        Ok(rows.into_iter().map(|record| record.path).collect())
     }
 
     fn unregister_root(&mut self, record: &Record) -> Result<()> {
-        verify_marker(record)?;
-        let rows = self.subtree(&record.id, false)?;
+        marker::verify(&record.path, &record.id)?;
+        let rows = self
+            .registry
+            .subtree(&record.id, SubtreeScope::DescendantsOnly)?;
         let existing = rows
             .into_iter()
-            .filter(|(_, path)| path.exists())
+            .filter(|record| record.path.exists())
             .collect::<Vec<_>>();
         self.trash_rows(&existing)?;
-        fs::remove_file(marker(&record.path))?;
-        self.database
-            .execute("DELETE FROM rift WHERE id = ?1", [&record.id])?;
+        fs::remove_file(marker::path(&record.path))?;
+        self.registry.delete_active(&record.id)?;
         Ok(())
     }
 
-    fn subtree(&self, id: &str, include_root: bool) -> Result<Vec<(String, PathBuf)>> {
-        let mut statement = self.database.prepare(
-            "WITH RECURSIVE subtree(id, path, depth) AS (
-               SELECT id, path, 0 FROM rift WHERE id = ?1
-               UNION ALL
-               SELECT rift.id, rift.path, subtree.depth + 1
-               FROM rift JOIN subtree ON rift.parent_id = subtree.id
-             ) SELECT id, path FROM subtree WHERE depth >= ?2 ORDER BY depth DESC, id",
-        )?;
-        let rows = statement
-            .query_map(params![id, if include_root { 0 } else { 1 }], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    PathBuf::from(row.get::<_, String>(1)?),
-                ))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        Ok(rows)
-    }
-
-    fn trash_rows(&mut self, rows: &[(String, PathBuf)]) -> Result<()> {
-        for (id, path) in rows {
-            if !path.exists() {
-                return Err(Error::MissingRift(path.clone()));
+    fn trash_rows(&mut self, rows: &[PathRecord]) -> Result<()> {
+        for row in rows {
+            if !row.path.exists() {
+                return Err(Error::MissingRift(row.path.clone()));
             }
-            verify_marker(&Record {
-                id: id.clone(),
-                parent_id: None,
-                path: path.clone(),
-            })?;
+            marker::verify(&row.path, &row.id)?;
         }
         let targets = rows
             .iter()
-            .map(|(id, path)| Ok((id, path, trash_path(id, path)?)))
+            .map(|row| {
+                Ok(MovedRecord {
+                    id: row.id.clone(),
+                    original_path: row.path.clone(),
+                    trash_path: trash_path(&row.id, &row.path)?,
+                })
+            })
             .collect::<Result<Vec<_>>>()?;
-        for (_, _, trash) in &targets {
-            if trash.exists() {
-                return Err(Error::AlreadyExists(trash.clone()));
+        for target in &targets {
+            if target.trash_path.exists() {
+                return Err(Error::AlreadyExists(target.trash_path.clone()));
             }
         }
-        let mut moved = Vec::with_capacity(rows.len());
-        for (id, path, trash) in targets {
-            fs::create_dir_all(trash.parent().unwrap())?;
-            if let Err(error) = fs::rename(path, &trash) {
-                for (_, original, trashed) in moved.iter().rev() {
-                    let _ = fs::rename(trashed, original);
+        let mut moved: Vec<MovedRecord> = Vec::with_capacity(rows.len());
+        for target in targets {
+            let trash_parent = target.trash_path.parent().ok_or_else(|| {
+                Error::Path(format!(
+                    "trash path has no parent: {}",
+                    target.trash_path.display()
+                ))
+            })?;
+            fs::create_dir_all(trash_parent)?;
+            if let Err(error) = fs::rename(&target.original_path, &target.trash_path) {
+                for record in moved.iter().rev() {
+                    let _ = fs::rename(&record.trash_path, &record.original_path);
                 }
                 return Err(error.into());
             }
-            moved.push((id, path, trash));
+            moved.push(target);
         }
-        let result = (|| {
-            let transaction = self.database.transaction()?;
-            for (id, _, path) in &moved {
-                transaction.execute(
-                    "INSERT INTO trash (id, path, removed_at) VALUES (?1, ?2, ?3)",
-                    params![id, path_text(path)?, timestamp()],
-                )?;
-                transaction.execute("DELETE FROM rift WHERE id = ?1", [id])?;
-            }
-            transaction.commit()?;
-            Ok(())
-        })();
+        let result = self.registry.trash_moved(&moved);
         if result.is_err() {
-            for (_, original, trashed) in moved.iter().rev() {
-                let _ = fs::rename(trashed, original);
+            for record in moved.iter().rev() {
+                let _ = fs::rename(&record.trash_path, &record.original_path);
             }
         }
         result
@@ -335,14 +293,7 @@ impl Manager {
 
     pub fn list(&self, of: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
         let record = self.workspace_at(of)?;
-        let mut statement = self
-            .database
-            .prepare("SELECT path FROM rift WHERE parent_id = ?1 ORDER BY created_at, id")?;
-        Ok(statement
-            .query_map([record.id], |row| {
-                Ok(PathBuf::from(row.get::<_, String>(0)?))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?)
+        self.registry.child_paths(&record.id)
     }
 
     pub fn ancestors(&self, of: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
@@ -351,6 +302,7 @@ impl Manager {
         let mut parent_id = record.parent_id;
         while let Some(id) = parent_id {
             let parent = self
+                .registry
                 .record_id(&id)?
                 .ok_or_else(|| Error::NotManaged(record.path.clone()))?;
             paths.push(parent.path);
@@ -360,58 +312,32 @@ impl Manager {
     }
 
     pub fn gc(&mut self) -> Result<Vec<PathBuf>> {
-        let mut statement = self
-            .database
-            .prepare("SELECT id, path FROM trash ORDER BY removed_at, id")?;
-        let rows = statement
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    PathBuf::from(row.get::<_, String>(1)?),
-                ))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        drop(statement);
         let mut removed = Vec::new();
-        for (id, path) in rows {
-            if path.exists() {
-                self.strategy.remove_directory(&path)?;
+        for row in self.registry.trashed_paths()? {
+            if row.path.exists() {
+                self.strategy.remove_directory(&row.path)?;
             }
-            self.database
-                .execute("DELETE FROM trash WHERE id = ?1", [&id])?;
-            removed.push(path);
+            self.registry.delete_trash(&row.id)?;
+            removed.push(row.path);
         }
 
-        let mut statement = self.database.prepare("SELECT id, path FROM rift")?;
-        let rows = statement
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    PathBuf::from(row.get::<_, String>(1)?),
-                ))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        drop(statement);
         let mut missing = Vec::new();
-        for (id, path) in rows {
-            if path.exists() {
+        for row in self.registry.active_paths()? {
+            if row.path.exists() {
                 continue;
             }
             if self
-                .subtree(&id, false)?
+                .registry
+                .subtree(&row.id, SubtreeScope::DescendantsOnly)?
                 .iter()
-                .any(|(_, descendant)| descendant.exists())
+                .any(|descendant| descendant.path.exists())
             {
                 continue;
             }
-            missing.push((id, path));
+            missing.push(row);
         }
-        let transaction = self.database.transaction()?;
-        for (id, path) in missing {
-            transaction.execute("DELETE FROM rift WHERE id = ?1", [&id])?;
-            removed.push(path);
-        }
-        transaction.commit()?;
+        self.registry.delete_active_records(&missing)?;
+        removed.extend(missing.into_iter().map(|record| record.path));
         Ok(removed)
     }
 
@@ -431,8 +357,9 @@ impl Manager {
 
     fn workspace_from_optional(&self, path: &Path) -> Result<Option<Record>> {
         for directory in path.ancestors() {
-            if let Some(id) = read_marker(directory)? {
+            if let Some(id) = marker::read(directory)? {
                 let record = self
+                    .registry
                     .record_id(&id)?
                     .ok_or_else(|| Error::UnknownMarker(directory.to_path_buf()))?;
                 if record.path != directory {
@@ -440,7 +367,7 @@ impl Manager {
                 }
                 return Ok(Some(record));
             }
-            if self.record_at_optional(directory)?.is_some() {
+            if self.registry.record_at(directory)?.is_some() {
                 return Err(Error::MissingMarker(directory.to_path_buf()));
             }
         }
@@ -451,44 +378,11 @@ impl Manager {
         let mut current = record.clone();
         while let Some(id) = current.parent_id.clone() {
             current = self
+                .registry
                 .record_id(&id)?
                 .ok_or_else(|| Error::NotManaged(record.path.clone()))?;
         }
         Ok(current)
-    }
-
-    fn record_at_optional(&self, path: &Path) -> Result<Option<Record>> {
-        self.database
-            .query_row(
-                "SELECT id, parent_id, path FROM rift WHERE path = ?1",
-                [path_text(path)?],
-                |row| {
-                    Ok(Record {
-                        id: row.get(0)?,
-                        parent_id: row.get(1)?,
-                        path: PathBuf::from(row.get::<_, String>(2)?),
-                    })
-                },
-            )
-            .optional()
-            .map_err(Error::from)
-    }
-
-    fn record_id(&self, id: &str) -> Result<Option<Record>> {
-        self.database
-            .query_row(
-                "SELECT id, parent_id, path FROM rift WHERE id = ?1",
-                [id],
-                |row| {
-                    Ok(Record {
-                        id: row.get(0)?,
-                        parent_id: row.get(1)?,
-                        path: PathBuf::from(row.get::<_, String>(2)?),
-                    })
-                },
-            )
-            .optional()
-            .map_err(Error::from)
     }
 }
 
@@ -523,7 +417,7 @@ fn default_storage(root: &Path) -> Result<PathBuf> {
     Ok(parent.join(".rifts").join(name))
 }
 
-fn trash_path(id: &str, path: &Path) -> Result<PathBuf> {
+fn trash_path(id: &RiftId, path: &Path) -> Result<PathBuf> {
     let parent = path
         .parent()
         .ok_or_else(|| Error::Path(format!("rift has no parent: {}", path.display())))?;
@@ -535,74 +429,6 @@ fn trash_path(id: &str, path: &Path) -> Result<PathBuf> {
         .join(format!("{id}-{}", name.to_string_lossy())))
 }
 
-fn destination_name(name: Option<String>) -> Result<String> {
-    let name = name.unwrap_or_else(generated_name);
-    if name.is_empty() || name == "." || name == ".." || Path::new(&name).components().count() != 1
-    {
-        return Err(Error::Path(format!("invalid rift name: {name}")));
-    }
-    Ok(name)
-}
-
-fn generated_name() -> String {
-    const ADJECTIVES: &[&str] = &[
-        "amber", "bold", "brisk", "calm", "cedar", "clear", "cobalt", "coral", "dawn", "ember",
-        "gentle", "golden", "jade", "lively", "lunar", "mellow", "misty", "noble", "quiet",
-        "rapid", "river", "silver", "solar", "spruce", "steady", "swift", "tidal", "verdant",
-        "violet", "warm", "wild", "winter",
-    ];
-    const NOUNS: &[&str] = &[
-        "badger", "brook", "canyon", "cedar", "comet", "dune", "falcon", "field", "forest",
-        "harbor", "heron", "island", "lantern", "maple", "meadow", "mesa", "otter", "peak", "pine",
-        "reef", "ridge", "robin", "sparrow", "summit", "thicket", "trail", "valley", "willow",
-        "wren", "yarrow", "zephyr", "fox",
-    ];
-
-    let mut rng = rand::rng();
-    format!(
-        "{}-{}",
-        ADJECTIVES[rng.random_range(0..ADJECTIVES.len())],
-        NOUNS[rng.random_range(0..NOUNS.len())]
-    )
-}
-
-fn marker(path: &Path) -> PathBuf {
-    path.join(".rift")
-}
-
-fn write_marker(path: &Path, id: &str) -> Result<()> {
-    fs::write(marker(path), format!("{id}\n"))?;
-    Ok(())
-}
-
-fn read_marker(path: &Path) -> Result<Option<String>> {
-    let marker = marker(path);
-    if !marker.exists() {
-        return Ok(None);
-    }
-    Ok(Some(fs::read_to_string(marker)?.trim().to_owned()))
-}
-
-fn verify_marker(record: &Record) -> Result<()> {
-    if read_marker(&record.path)?.as_deref() == Some(&record.id) {
-        return Ok(());
-    }
-    Err(Error::MarkerMismatch(record.path.clone()))
-}
-
-fn path_text(path: &Path) -> Result<String> {
-    path.to_str()
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| Error::Path(format!("path is not valid UTF-8: {}", path.display())))
-}
-
-fn timestamp() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as i64
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -611,6 +437,7 @@ mod tests {
     use std::process::Command;
     use std::rc::Rc;
     use tempfile::TempDir;
+    use ulid::Ulid;
 
     fn manager(temp: &TempDir) -> Manager {
         Manager::with_strategy(temp.path().join("registry.sqlite"), Box::new(TestStrategy)).unwrap()
@@ -621,6 +448,10 @@ mod tests {
         fs::create_dir(&source).unwrap();
         fs::write(source.join("file.txt"), "hello").unwrap();
         fs::canonicalize(source).unwrap()
+    }
+
+    fn marker_id(path: &Path) -> RiftId {
+        marker::read(path).unwrap().unwrap()
     }
 
     #[test]
@@ -747,7 +578,7 @@ mod tests {
             Err(Error::UnknownMarker(_))
         ));
 
-        let id = manager.record_at_optional(&source).unwrap().unwrap().id;
+        let id = manager.registry.record_at(&source).unwrap().unwrap().id;
         fs::write(source.join(".rift"), format!("{id}\n")).unwrap();
         let other = temp.path().join("other");
         fs::create_dir(&other).unwrap();
@@ -771,7 +602,7 @@ mod tests {
                 into: None,
             })
             .unwrap();
-        let id = fs::read_to_string(child.join(".rift")).unwrap();
+        let id = marker_id(&child);
         fs::write(child.join(".rift"), "wrong\n").unwrap();
         assert!(matches!(
             manager.remove(&child),
@@ -786,8 +617,8 @@ mod tests {
             manager.remove(&child),
             Err(Error::MarkerMismatch(_))
         ));
-        fs::write(child.join(".rift"), &id).unwrap();
-        let trash = trash_path(id.trim(), &child).unwrap();
+        fs::write(child.join(".rift"), format!("{id}\n")).unwrap();
+        let trash = trash_path(&id, &child).unwrap();
         fs::create_dir_all(&trash).unwrap();
         assert!(matches!(
             manager.remove(&child),
@@ -808,8 +639,8 @@ mod tests {
                 into: None,
             })
             .unwrap();
-        let id = fs::read_to_string(child.join(".rift")).unwrap();
-        let trash = trash_path(id.trim(), &child).unwrap();
+        let id = marker_id(&child);
+        let trash = trash_path(&id, &child).unwrap();
         manager.remove(&child).unwrap();
         fs::remove_dir_all(&trash).unwrap();
 
@@ -986,22 +817,10 @@ mod tests {
             })
             .unwrap();
 
-        let first_trash = trash_path(
-            &fs::read_to_string(first.join(".rift"))
-                .unwrap()
-                .trim()
-                .to_owned(),
-            &first,
-        )
-        .unwrap();
-        let second_trash = trash_path(
-            &fs::read_to_string(second.join(".rift"))
-                .unwrap()
-                .trim()
-                .to_owned(),
-            &second,
-        )
-        .unwrap();
+        let first_id = marker_id(&first);
+        let first_trash = trash_path(&first_id, &first).unwrap();
+        let second_id = marker_id(&second);
+        let second_trash = trash_path(&second_id, &second).unwrap();
 
         manager.remove(&first).unwrap();
 
@@ -1038,16 +857,10 @@ mod tests {
                 into: None,
             })
             .unwrap();
-        let first_trash = trash_path(
-            fs::read_to_string(first.join(".rift")).unwrap().trim(),
-            &first,
-        )
-        .unwrap();
-        let second_trash = trash_path(
-            fs::read_to_string(second.join(".rift")).unwrap().trim(),
-            &second,
-        )
-        .unwrap();
+        let first_id = marker_id(&first);
+        let first_trash = trash_path(&first_id, &first).unwrap();
+        let second_id = marker_id(&second);
+        let second_trash = trash_path(&second_id, &second).unwrap();
 
         manager.remove(&source).unwrap();
 
@@ -1118,8 +931,8 @@ mod tests {
                 into: None,
             })
             .unwrap();
-        let first_id = fs::read_to_string(first.join(".rift")).unwrap();
-        let first_trash = trash_path(first_id.trim(), &first).unwrap();
+        let first_id = marker_id(&first);
+        let first_trash = trash_path(&first_id, &first).unwrap();
 
         let removed = manager.remove_all(&source).unwrap();
         assert_eq!(removed[0], second);
@@ -1204,10 +1017,10 @@ mod tests {
                 into: None,
             })
             .unwrap();
-        let first_id = fs::read_to_string(first.join(".rift")).unwrap();
-        let second_id = fs::read_to_string(second.join(".rift")).unwrap();
-        let first_trash = trash_path(first_id.trim(), &first).unwrap();
-        let second_trash = trash_path(second_id.trim(), &second).unwrap();
+        let first_id = marker_id(&first);
+        let second_id = marker_id(&second);
+        let first_trash = trash_path(&first_id, &first).unwrap();
+        let second_trash = trash_path(&second_id, &second).unwrap();
         manager.remove(&first).unwrap();
 
         let deleted = manager.gc().unwrap();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -143,11 +143,11 @@ impl Manager {
 
         let result = (|| {
             write_marker(&destination, &id)?;
-            if git {
+            if git.is_repository() {
                 git::hide_marker(&destination)?;
                 git::detach_destination(&destination)?;
             }
-            if git {
+            if git.is_repository() {
                 git::hide_marker(&from)?;
             }
             self.database.execute(
@@ -181,7 +181,7 @@ impl Manager {
                 verify_marker(&record)?;
             }
             let converted = self.strategy.initialize_directory(&at, &mut progress)?;
-            if git {
+            if git.is_repository() {
                 git::hide_marker(&at)?;
             }
             return Ok(converted);
@@ -195,7 +195,7 @@ impl Manager {
         let id = Ulid::new().to_string();
         let result = (|| {
             write_marker(&at, &id)?;
-            if git {
+            if git.is_repository() {
                 git::hide_marker(&at)?;
             }
             self.database.execute(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -244,12 +244,14 @@ impl Manager {
     }
 
     fn trash_rows(&mut self, rows: &[PathRecord]) -> Result<()> {
-        for row in rows {
-            if !row.path.exists() {
-                return Err(Error::MissingRift(row.path.clone()));
-            }
+        rows.iter().try_for_each(|row| -> Result<()> {
+            row.path
+                .exists()
+                .then_some(())
+                .ok_or_else(|| Error::MissingRift(row.path.clone()))?;
             marker::verify(&row.path, &row.id)?;
-        }
+            Ok(())
+        })?;
         let targets = rows
             .iter()
             .map(|row| {
@@ -260,11 +262,11 @@ impl Manager {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        for target in &targets {
-            if target.trash_path.exists() {
-                return Err(Error::AlreadyExists(target.trash_path.clone()));
-            }
-        }
+        targets.iter().try_for_each(|target| {
+            (!target.trash_path.exists())
+                .then_some(())
+                .ok_or_else(|| Error::AlreadyExists(target.trash_path.clone()))
+        })?;
         let mut moved: Vec<MovedRecord> = Vec::with_capacity(rows.len());
         for target in targets {
             let trash_parent = target.trash_path.parent().ok_or_else(|| {
@@ -312,33 +314,41 @@ impl Manager {
     }
 
     pub fn gc(&mut self) -> Result<Vec<PathBuf>> {
-        let mut removed = Vec::new();
-        for row in self.registry.trashed_paths()? {
-            if row.path.exists() {
-                self.strategy.remove_directory(&row.path)?;
-            }
-            self.registry.delete_trash(&row.id)?;
-            removed.push(row.path);
-        }
+        let removed = self
+            .registry
+            .trashed_paths()?
+            .into_iter()
+            .map(|row| -> Result<PathBuf> {
+                if row.path.exists() {
+                    self.strategy.remove_directory(&row.path)?;
+                }
+                self.registry.delete_trash(&row.id)?;
+                Ok(row.path)
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-        let mut missing = Vec::new();
-        for row in self.registry.active_paths()? {
-            if row.path.exists() {
-                continue;
-            }
-            if self
-                .registry
-                .subtree(&row.id, SubtreeScope::DescendantsOnly)?
-                .iter()
-                .any(|descendant| descendant.path.exists())
-            {
-                continue;
-            }
-            missing.push(row);
-        }
+        let missing = self
+            .registry
+            .active_paths()?
+            .into_iter()
+            .filter(|row| !row.path.exists())
+            .map(|row| {
+                self.registry
+                    .subtree(&row.id, SubtreeScope::DescendantsOnly)
+                    .map(|descendants| {
+                        (!descendants
+                            .iter()
+                            .any(|descendant| descendant.path.exists()))
+                        .then_some(row)
+                    })
+            })
+            .filter_map(Result::transpose)
+            .collect::<Result<Vec<_>>>()?;
         self.registry.delete_active_records(&missing)?;
-        removed.extend(missing.into_iter().map(|record| record.path));
-        Ok(removed)
+        Ok(removed
+            .into_iter()
+            .chain(missing.into_iter().map(|record| record.path))
+            .collect())
     }
 
     pub fn workspace(&self, at: impl AsRef<Path>) -> Result<PathBuf> {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use rusqlite::{Connection, OptionalExtension, params};
 use std::fs;
 use std::path::{Path, PathBuf};
-use strategy::Strategy;
+use strategy::{Strategy, StrategyInit};
 use thiserror::Error;
 use ulid::Ulid;
 
@@ -62,6 +62,19 @@ pub enum InitProgress {
     RemovingOriginal,
     RestoringMarker,
     RegisteringWorkspace,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InitOutcome {
+    Registered,
+    AlreadyInitialized,
+    Converted,
+}
+
+impl InitOutcome {
+    pub fn is_converted(self) -> bool {
+        matches!(self, Self::Converted)
+    }
 }
 
 #[derive(Clone)]
@@ -162,7 +175,7 @@ impl Manager {
         result
     }
 
-    pub fn init(&mut self, at: impl AsRef<Path>) -> Result<bool> {
+    pub fn init(&mut self, at: impl AsRef<Path>) -> Result<InitOutcome> {
         self.init_with_progress(at, |_| {})
     }
 
@@ -170,7 +183,7 @@ impl Manager {
         &mut self,
         at: impl AsRef<Path>,
         mut progress: impl FnMut(InitProgress),
-    ) -> Result<bool> {
+    ) -> Result<InitOutcome> {
         let at = existing_directory(at.as_ref())?;
         let git = git::check_source(&at)?;
         if let Some(record) = self.record_at_optional(&at)? {
@@ -184,7 +197,10 @@ impl Manager {
             if git.is_repository() {
                 git::hide_marker(&at)?;
             }
-            return Ok(converted);
+            return Ok(match converted {
+                StrategyInit::AlreadyNative => InitOutcome::AlreadyInitialized,
+                StrategyInit::Converted => InitOutcome::Converted,
+            });
         }
         if read_marker(&at)?.is_some() {
             return Err(Error::MarkerMismatch(at));
@@ -202,7 +218,10 @@ impl Manager {
                 "INSERT INTO rift (id, parent_id, path, created_at) VALUES (?1, NULL, ?2, ?3)",
                 params![id, path_text(&at)?, timestamp()],
             )?;
-            Ok(converted)
+            Ok(match converted {
+                StrategyInit::AlreadyNative => InitOutcome::Registered,
+                StrategyInit::Converted => InitOutcome::Converted,
+            })
         })();
         if result.is_err() {
             let _ = fs::remove_file(marker(&at));
@@ -642,10 +661,13 @@ mod tests {
         let source = source(&temp);
         let mut manager = manager(&temp);
 
-        assert!(!manager.init(&source).unwrap());
+        assert_eq!(manager.init(&source).unwrap(), InitOutcome::Registered);
         assert!(source.join(".rift").exists());
         assert!(manager.list(&source).unwrap().is_empty());
-        assert!(!manager.init(&source).unwrap());
+        assert_eq!(
+            manager.init(&source).unwrap(),
+            InitOutcome::AlreadyInitialized
+        );
     }
 
     #[test]
@@ -867,9 +889,9 @@ mod tests {
             &self,
             _path: &Path,
             _progress: &mut dyn FnMut(InitProgress),
-        ) -> Result<bool> {
+        ) -> Result<StrategyInit> {
             self.initialized.set(true);
-            Ok(true)
+            Ok(StrategyInit::Converted)
         }
     }
 
@@ -890,7 +912,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(manager.init(&source).unwrap());
+        assert_eq!(manager.init(&source).unwrap(), InitOutcome::Converted);
         assert!(initialized.get());
         assert!(source.join(".rift").exists());
     }

--- a/crates/core/src/marker.rs
+++ b/crates/core/src/marker.rs
@@ -1,0 +1,28 @@
+use crate::{Error, Result, id::RiftId};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn path(workspace: &Path) -> PathBuf {
+    workspace.join(".rift")
+}
+
+pub(crate) fn write(workspace: &Path, id: &RiftId) -> Result<()> {
+    fs::write(path(workspace), format!("{id}\n"))?;
+    Ok(())
+}
+
+pub(crate) fn read(workspace: &Path) -> Result<Option<RiftId>> {
+    let contents = match fs::read_to_string(path(workspace)) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(Some(RiftId::from_stored(contents.trim().to_owned())))
+}
+
+pub(crate) fn verify(workspace: &Path, expected_id: &RiftId) -> Result<()> {
+    if read(workspace)?.as_ref() == Some(expected_id) {
+        return Ok(());
+    }
+    Err(Error::MarkerMismatch(workspace.to_path_buf()))
+}

--- a/crates/core/src/name.rs
+++ b/crates/core/src/name.rs
@@ -1,0 +1,76 @@
+use crate::{Error, Result};
+use rand::Rng;
+use std::path::Path;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RiftName(String);
+
+impl RiftName {
+    pub(crate) fn from_optional(name: Option<String>) -> Result<Self> {
+        Self::new(name.unwrap_or_else(generated_name))
+    }
+
+    fn new(name: String) -> Result<Self> {
+        if name.is_empty()
+            || name == "."
+            || name == ".."
+            || Path::new(&name).components().count() != 1
+        {
+            return Err(Error::Path(format!("invalid rift name: {name}")));
+        }
+        Ok(Self(name))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn generated_name() -> String {
+    const ADJECTIVES: &[&str] = &[
+        "amber", "bold", "brisk", "calm", "cedar", "clear", "cobalt", "coral", "dawn", "ember",
+        "gentle", "golden", "jade", "lively", "lunar", "mellow", "misty", "noble", "quiet",
+        "rapid", "river", "silver", "solar", "spruce", "steady", "swift", "tidal", "verdant",
+        "violet", "warm", "wild", "winter",
+    ];
+    const NOUNS: &[&str] = &[
+        "badger", "brook", "canyon", "cedar", "comet", "dune", "falcon", "field", "forest",
+        "harbor", "heron", "island", "lantern", "maple", "meadow", "mesa", "otter", "peak", "pine",
+        "reef", "ridge", "robin", "sparrow", "summit", "thicket", "trail", "valley", "willow",
+        "wren", "yarrow", "zephyr", "fox",
+    ];
+
+    let mut rng = rand::rng();
+    format!(
+        "{}-{}",
+        ADJECTIVES[rng.random_range(0..ADJECTIVES.len())],
+        NOUNS[rng.random_range(0..NOUNS.len())]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_are_single_path_segments() {
+        assert_eq!(RiftName::new("child".into()).unwrap().as_str(), "child");
+        assert!(RiftName::new(String::new()).is_err());
+        assert!(RiftName::new(".".into()).is_err());
+        assert!(RiftName::new("..".into()).is_err());
+        assert!(RiftName::new("parent/child".into()).is_err());
+    }
+
+    #[test]
+    fn generated_names_are_readable_segments() {
+        let name = RiftName::from_optional(None).unwrap();
+        let parts = name.as_str().split('-').collect::<Vec<_>>();
+
+        assert_eq!(parts.len(), 2);
+        assert!(
+            parts
+                .iter()
+                .all(|part| part.chars().all(|character| character.is_ascii_lowercase()))
+        );
+    }
+}

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -1,0 +1,310 @@
+use crate::{Error, Result, id::RiftId};
+use rusqlite::{Connection, OptionalExtension, Row, params};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub(crate) struct Record {
+    pub(crate) id: RiftId,
+    pub(crate) parent_id: Option<RiftId>,
+    pub(crate) path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PathRecord {
+    pub(crate) id: RiftId,
+    pub(crate) path: PathBuf,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct MovedRecord {
+    pub(crate) id: RiftId,
+    pub(crate) original_path: PathBuf,
+    pub(crate) trash_path: PathBuf,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SubtreeScope {
+    IncludingRoot,
+    DescendantsOnly,
+}
+
+impl SubtreeScope {
+    fn min_depth(self) -> u8 {
+        match self {
+            Self::IncludingRoot => 0,
+            Self::DescendantsOnly => 1,
+        }
+    }
+}
+
+pub(crate) struct Registry {
+    database: Connection,
+}
+
+impl Registry {
+    pub(crate) fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let database = Connection::open(path)?;
+        database.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE IF NOT EXISTS rift (
+               id TEXT PRIMARY KEY,
+               parent_id TEXT REFERENCES rift(id) ON DELETE CASCADE,
+               path TEXT NOT NULL UNIQUE,
+               created_at INTEGER NOT NULL
+              );
+              CREATE INDEX IF NOT EXISTS rift_parent_id_idx ON rift(parent_id);
+              CREATE TABLE IF NOT EXISTS trash (
+                id TEXT PRIMARY KEY,
+                path TEXT NOT NULL UNIQUE,
+                removed_at INTEGER NOT NULL
+              );",
+        )?;
+        Ok(Self { database })
+    }
+
+    pub(crate) fn insert_root(&self, id: &RiftId, path: &Path) -> Result<()> {
+        self.database.execute(
+            "INSERT INTO rift (id, parent_id, path, created_at) VALUES (?1, NULL, ?2, ?3)",
+            params![id.as_str(), path_text(path)?, timestamp()],
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn insert_child(&self, id: &RiftId, parent_id: &RiftId, path: &Path) -> Result<()> {
+        self.database.execute(
+            "INSERT INTO rift (id, parent_id, path, created_at) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                id.as_str(),
+                parent_id.as_str(),
+                path_text(path)?,
+                timestamp()
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn record_at(&self, path: &Path) -> Result<Option<Record>> {
+        self.database
+            .query_row(
+                "SELECT id, parent_id, path FROM rift WHERE path = ?1",
+                [path_text(path)?],
+                record_from_row,
+            )
+            .optional()
+            .map_err(Error::from)
+    }
+
+    pub(crate) fn record_id(&self, id: &RiftId) -> Result<Option<Record>> {
+        self.database
+            .query_row(
+                "SELECT id, parent_id, path FROM rift WHERE id = ?1",
+                [id.as_str()],
+                record_from_row,
+            )
+            .optional()
+            .map_err(Error::from)
+    }
+
+    pub(crate) fn subtree(&self, id: &RiftId, scope: SubtreeScope) -> Result<Vec<PathRecord>> {
+        let mut statement = self.database.prepare(
+            "WITH RECURSIVE subtree(id, path, depth) AS (
+               SELECT id, path, 0 FROM rift WHERE id = ?1
+               UNION ALL
+               SELECT rift.id, rift.path, subtree.depth + 1
+               FROM rift JOIN subtree ON rift.parent_id = subtree.id
+             ) SELECT id, path FROM subtree WHERE depth >= ?2 ORDER BY depth DESC, id",
+        )?;
+        let rows = statement
+            .query_map(params![id.as_str(), scope.min_depth()], |row| {
+                Ok(PathRecord {
+                    id: RiftId::from_stored(row.get(0)?),
+                    path: PathBuf::from(row.get::<_, String>(1)?),
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    pub(crate) fn child_paths(&self, parent_id: &RiftId) -> Result<Vec<PathBuf>> {
+        let mut statement = self
+            .database
+            .prepare("SELECT path FROM rift WHERE parent_id = ?1 ORDER BY created_at, id")?;
+        Ok(statement
+            .query_map([parent_id.as_str()], |row| {
+                Ok(PathBuf::from(row.get::<_, String>(0)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    pub(crate) fn delete_active(&self, id: &RiftId) -> Result<()> {
+        self.database
+            .execute("DELETE FROM rift WHERE id = ?1", [id.as_str()])?;
+        Ok(())
+    }
+
+    pub(crate) fn trash_moved(&mut self, moved: &[MovedRecord]) -> Result<()> {
+        let transaction = self.database.transaction()?;
+        for record in moved {
+            transaction.execute(
+                "INSERT INTO trash (id, path, removed_at) VALUES (?1, ?2, ?3)",
+                params![
+                    record.id.as_str(),
+                    path_text(&record.trash_path)?,
+                    timestamp()
+                ],
+            )?;
+            transaction.execute("DELETE FROM rift WHERE id = ?1", [record.id.as_str()])?;
+        }
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub(crate) fn trashed_paths(&self) -> Result<Vec<PathRecord>> {
+        let mut statement = self
+            .database
+            .prepare("SELECT id, path FROM trash ORDER BY removed_at, id")?;
+        Ok(statement
+            .query_map([], |row| {
+                Ok(PathRecord {
+                    id: RiftId::from_stored(row.get(0)?),
+                    path: PathBuf::from(row.get::<_, String>(1)?),
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    pub(crate) fn delete_trash(&self, id: &RiftId) -> Result<()> {
+        self.database
+            .execute("DELETE FROM trash WHERE id = ?1", [id.as_str()])?;
+        Ok(())
+    }
+
+    pub(crate) fn active_paths(&self) -> Result<Vec<PathRecord>> {
+        let mut statement = self.database.prepare("SELECT id, path FROM rift")?;
+        Ok(statement
+            .query_map([], |row| {
+                Ok(PathRecord {
+                    id: RiftId::from_stored(row.get(0)?),
+                    path: PathBuf::from(row.get::<_, String>(1)?),
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    pub(crate) fn delete_active_records(&mut self, rows: &[PathRecord]) -> Result<()> {
+        let transaction = self.database.transaction()?;
+        for record in rows {
+            transaction.execute("DELETE FROM rift WHERE id = ?1", [record.id.as_str()])?;
+        }
+        transaction.commit()?;
+        Ok(())
+    }
+}
+
+fn record_from_row(row: &Row<'_>) -> rusqlite::Result<Record> {
+    Ok(Record {
+        id: RiftId::from_stored(row.get(0)?),
+        parent_id: row.get::<_, Option<String>>(1)?.map(RiftId::from_stored),
+        path: PathBuf::from(row.get::<_, String>(2)?),
+    })
+}
+
+fn path_text(path: &Path) -> Result<String> {
+    path.to_str()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| Error::Path(format!("path is not valid UTF-8: {}", path.display())))
+}
+
+fn timestamp() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn registry() -> (TempDir, Registry) {
+        let temp = TempDir::new().unwrap();
+        let registry = Registry::open(temp.path().join("registry.sqlite")).unwrap();
+        (temp, registry)
+    }
+
+    #[test]
+    fn subtree_returns_descendants_before_ancestors() {
+        let (temp, registry) = registry();
+        let root = temp.path().join("root");
+        let child = temp.path().join("child");
+        let sibling = temp.path().join("sibling");
+        let grandchild = temp.path().join("grandchild");
+        let root_id = id("root");
+        let child_id = id("child");
+        let sibling_id = id("sibling");
+        let grandchild_id = id("grandchild");
+        registry.insert_root(&root_id, &root).unwrap();
+        registry.insert_child(&child_id, &root_id, &child).unwrap();
+        registry
+            .insert_child(&sibling_id, &root_id, &sibling)
+            .unwrap();
+        registry
+            .insert_child(&grandchild_id, &child_id, &grandchild)
+            .unwrap();
+
+        let subtree = registry
+            .subtree(&root_id, SubtreeScope::IncludingRoot)
+            .unwrap()
+            .into_iter()
+            .map(|record| record.id.to_string())
+            .collect::<Vec<_>>();
+        let descendants = registry
+            .subtree(&root_id, SubtreeScope::DescendantsOnly)
+            .unwrap()
+            .into_iter()
+            .map(|record| record.id.to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(subtree, vec!["grandchild", "child", "sibling", "root"]);
+        assert_eq!(descendants, vec!["grandchild", "child", "sibling"]);
+        assert_eq!(
+            registry.child_paths(&root_id).unwrap(),
+            vec![child, sibling]
+        );
+    }
+
+    #[test]
+    fn trash_moved_transfers_records_from_active_tree_to_trash() {
+        let (temp, mut registry) = registry();
+        let root = temp.path().join("root");
+        let child = temp.path().join("child");
+        let trash = temp.path().join(".trash/child");
+        let root_id = id("root");
+        let child_id = id("child");
+        registry.insert_root(&root_id, &root).unwrap();
+        registry.insert_child(&child_id, &root_id, &child).unwrap();
+
+        registry
+            .trash_moved(&[MovedRecord {
+                id: child_id.clone(),
+                original_path: child.clone(),
+                trash_path: trash.clone(),
+            }])
+            .unwrap();
+
+        assert!(registry.record_id(&root_id).unwrap().is_some());
+        assert!(registry.record_id(&child_id).unwrap().is_none());
+        assert_eq!(
+            registry.trashed_paths().unwrap(),
+            vec![PathRecord {
+                id: child_id,
+                path: trash,
+            }]
+        );
+    }
+
+    fn id(value: &str) -> RiftId {
+        RiftId::from_stored(value.to_owned())
+    }
+}

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -144,7 +144,7 @@ impl Registry {
 
     pub(crate) fn trash_moved(&mut self, moved: &[MovedRecord]) -> Result<()> {
         let transaction = self.database.transaction()?;
-        for record in moved {
+        moved.iter().try_for_each(|record| -> Result<()> {
             transaction.execute(
                 "INSERT INTO trash (id, path, removed_at) VALUES (?1, ?2, ?3)",
                 params![
@@ -154,7 +154,8 @@ impl Registry {
                 ],
             )?;
             transaction.execute("DELETE FROM rift WHERE id = ?1", [record.id.as_str()])?;
-        }
+            Ok(())
+        })?;
         transaction.commit()?;
         Ok(())
     }
@@ -193,9 +194,10 @@ impl Registry {
 
     pub(crate) fn delete_active_records(&mut self, rows: &[PathRecord]) -> Result<()> {
         let transaction = self.database.transaction()?;
-        for record in rows {
+        rows.iter().try_for_each(|record| -> Result<()> {
             transaction.execute("DELETE FROM rift WHERE id = ?1", [record.id.as_str()])?;
-        }
+            Ok(())
+        })?;
         transaction.commit()?;
         Ok(())
     }

--- a/crates/core/src/strategy/apfs.rs
+++ b/crates/core/src/strategy/apfs.rs
@@ -13,6 +13,8 @@ impl Strategy for ApfsStrategy {
             .map_err(|_| Error::Path(format!("path contains a null byte: {}", from.display())))?;
         let destination = CString::new(to.as_os_str().as_bytes())
             .map_err(|_| Error::Path(format!("path contains a null byte: {}", to.display())))?;
+        // SAFETY: `source` and `destination` are null-terminated C strings
+        // built above, and both live for the duration of the call.
         let result = unsafe { libc::clonefile(source.as_ptr(), destination.as_ptr(), 0) };
         if result == 0 {
             return Ok(());

--- a/crates/core/src/strategy/btrfs.rs
+++ b/crates/core/src/strategy/btrfs.rs
@@ -38,7 +38,10 @@ fn copy_directory_linux(from: &Path, to: &Path) -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-fn initialize_directory_linux(path: &Path, progress: &mut dyn FnMut(InitProgress)) -> Result<bool> {
+fn initialize_directory_linux(
+    path: &Path,
+    progress: &mut dyn FnMut(InitProgress),
+) -> Result<bool> {
     if !is_btrfs_filesystem(path)? {
         return Err(Error::CowUnavailable(format!(
             "{} is not on a btrfs filesystem",
@@ -78,7 +81,7 @@ fn initialize_directory_linux(path: &Path, progress: &mut dyn FnMut(InitProgress
                 ))),
             };
         }
-        copy_metadata_linux(&original, path, false)?;
+        copy_metadata_linux(&original, path, MetadataTarget::FileOrDirectory)?;
         progress(InitProgress::RemovingOriginal);
         fs::remove_dir_all(&original).map_err(|error| {
             Error::CowUnavailable(format!(
@@ -130,10 +133,10 @@ fn import_directory_linux(
             } else {
                 reflink_file_linux(source, &destination)?;
             }
-            copy_metadata_linux(source, &destination, false)?;
+            copy_metadata_linux(source, &destination, MetadataTarget::FileOrDirectory)?;
         } else if file_type.is_symlink() {
             std::os::unix::fs::symlink(fs::read_link(source)?, &destination)?;
-            copy_metadata_linux(source, &destination, true)?;
+            copy_metadata_linux(source, &destination, MetadataTarget::Symlink)?;
         } else {
             return Err(Error::UnsupportedEntry(source.to_path_buf()));
         }
@@ -141,7 +144,7 @@ fn import_directory_linux(
         progress(InitProgress::ImportedEntries { entries });
     }
     for (source, destination) in directories.into_iter().rev() {
-        copy_metadata_linux(&source, &destination, false)?;
+        copy_metadata_linux(&source, &destination, MetadataTarget::FileOrDirectory)?;
     }
     Ok(())
 }
@@ -154,6 +157,8 @@ fn reflink_file_linux(from: &Path, to: &Path) -> Result<()> {
     const FICLONE: libc::c_ulong = 0x4004_9409;
     let source = File::open(from)?;
     let destination = OpenOptions::new().write(true).create_new(true).open(to)?;
+    // SAFETY: both file descriptors come from live `File` values, and FICLONE
+    // only reads the source fd while mutating the destination file.
     if unsafe { libc::ioctl(destination.as_raw_fd(), FICLONE, source.as_raw_fd()) } == 0 {
         return Ok(());
     }
@@ -165,15 +170,24 @@ fn reflink_file_linux(from: &Path, to: &Path) -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-fn copy_metadata_linux(from: &Path, to: &Path, symlink: bool) -> Result<()> {
+#[derive(Clone, Copy)]
+enum MetadataTarget {
+    FileOrDirectory,
+    Symlink,
+}
+
+#[cfg(target_os = "linux")]
+fn copy_metadata_linux(from: &Path, to: &Path, target: MetadataTarget) -> Result<()> {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     let metadata = fs::symlink_metadata(from)?;
     let destination = c_path(to)?;
+    // SAFETY: `destination` is a valid null-terminated path, and uid/gid come
+    // from filesystem metadata for `from`.
     if unsafe { libc::lchown(destination.as_ptr(), metadata.uid(), metadata.gid()) } != 0 {
         return Err(std::io::Error::last_os_error().into());
     }
-    if !symlink {
+    if matches!(target, MetadataTarget::FileOrDirectory) {
         fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))?;
     }
     copy_xattrs_linux(from, to)?;
@@ -187,6 +201,8 @@ fn copy_metadata_linux(from: &Path, to: &Path, symlink: bool) -> Result<()> {
             tv_nsec: metadata.mtime_nsec(),
         },
     ];
+    // SAFETY: `destination` is a live C string and `times` contains exactly the
+    // two timestamps expected by `utimensat`.
     if unsafe {
         libc::utimensat(
             libc::AT_FDCWD,
@@ -205,11 +221,15 @@ fn copy_metadata_linux(from: &Path, to: &Path, symlink: bool) -> Result<()> {
 fn copy_xattrs_linux(from: &Path, to: &Path) -> Result<()> {
     let from = c_path(from)?;
     let to = c_path(to)?;
+    // SAFETY: `from` is a valid C path. A null buffer with size 0 asks the
+    // kernel for the required list size.
     let size = unsafe { libc::llistxattr(from.as_ptr(), std::ptr::null_mut(), 0) };
     if size < 0 {
         return Err(std::io::Error::last_os_error().into());
     }
     let mut names = vec![0_u8; size as usize];
+    // SAFETY: `names` was allocated with the size reported by the previous
+    // `llistxattr` call, and its pointer is valid for writes of that length.
     if size > 0
         && unsafe { libc::llistxattr(from.as_ptr(), names.as_mut_ptr().cast(), names.len()) } < 0
     {
@@ -221,12 +241,16 @@ fn copy_xattrs_linux(from: &Path, to: &Path) -> Result<()> {
     {
         let name = std::ffi::CString::new(name)
             .map_err(|_| Error::Path("extended attribute name contains a null byte".into()))?;
+        // SAFETY: `from` and `name` are valid C strings. A null buffer with
+        // size 0 asks the kernel for this attribute's value length.
         let size =
             unsafe { libc::lgetxattr(from.as_ptr(), name.as_ptr(), std::ptr::null_mut(), 0) };
         if size < 0 {
             return Err(std::io::Error::last_os_error().into());
         }
         let mut value = vec![0_u8; size as usize];
+        // SAFETY: `value` was allocated with the exact size reported by
+        // `lgetxattr`, and the path and attribute name are valid C strings.
         if size > 0
             && unsafe {
                 libc::lgetxattr(
@@ -239,6 +263,8 @@ fn copy_xattrs_linux(from: &Path, to: &Path) -> Result<()> {
         {
             return Err(std::io::Error::last_os_error().into());
         }
+        // SAFETY: `to` and `name` are valid C strings, and `value` points to
+        // an initialized byte buffer of the supplied length.
         if unsafe {
             libc::lsetxattr(
                 to.as_ptr(),
@@ -290,7 +316,11 @@ fn is_btrfs_filesystem(path: &Path) -> Result<bool> {
     const BTRFS_SUPER_MAGIC: libc::c_long = 0x9123_683e;
     let path = CString::new(path.as_os_str().as_bytes())
         .map_err(|_| Error::Path(format!("path contains a null byte: {}", path.display())))?;
+    // SAFETY: `statfs` is a plain C struct; zero initialization is a valid
+    // starting state before the kernel fills it.
     let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
+    // SAFETY: `path` is a valid C string, and `stat` points to writable memory
+    // for the kernel to initialize.
     if unsafe { libc::statfs(path.as_ptr(), &mut stat) } != 0 {
         return Err(std::io::Error::last_os_error().into());
     }
@@ -393,6 +423,8 @@ fn btrfs_path_ioctl(
         *destination = *byte as libc::c_char;
     }
     let parent = File::open(parent)?;
+    // SAFETY: `parent` is an open directory fd, and `args` has the C layout
+    // expected by the btrfs volume ioctls for the duration of this call.
     let result = unsafe { libc::ioctl(parent.as_raw_fd(), request, &args) };
     if result == 0 {
         return Ok(());
@@ -435,6 +467,8 @@ mod linux_tests {
         let path = c_path(path).unwrap();
         let name = std::ffi::CString::new(name).unwrap();
         assert_eq!(
+            // SAFETY: test inputs are valid C strings and `value` is a live
+            // byte slice whose contents are copied by the kernel.
             unsafe {
                 libc::lsetxattr(
                     path.as_ptr(),
@@ -451,11 +485,15 @@ mod linux_tests {
     fn get_xattr(path: &Path, name: &str) -> Vec<u8> {
         let path = c_path(path).unwrap();
         let name = std::ffi::CString::new(name).unwrap();
+        // SAFETY: test inputs are valid C strings. A null buffer with size 0
+        // requests the attribute value length.
         let size =
             unsafe { libc::lgetxattr(path.as_ptr(), name.as_ptr(), std::ptr::null_mut(), 0) };
         assert!(size >= 0);
         let mut value = vec![0; size as usize];
         assert_eq!(
+            // SAFETY: `value` is allocated with the exact size returned by
+            // `lgetxattr`, and the C strings live for this call.
             unsafe {
                 libc::lgetxattr(
                     path.as_ptr(),
@@ -570,6 +608,8 @@ mod linux_tests {
         fs::create_dir(&to).unwrap();
         let fifo = from.join("fifo");
         let fifo_name = c_path(&fifo).unwrap();
+        // SAFETY: `fifo_name` is a valid C path and the mode is a normal
+        // permission bitmask for creating a FIFO in this test.
         assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
         assert!(matches!(
             import_directory_linux(&from, &to, &mut |_| {}),

--- a/crates/core/src/strategy/btrfs.rs
+++ b/crates/core/src/strategy/btrfs.rs
@@ -1,4 +1,4 @@
-use super::Strategy;
+use super::{Strategy, StrategyInit};
 use crate::{Error, InitProgress, Result};
 use std::fs;
 use std::path::Path;
@@ -15,7 +15,7 @@ impl Strategy for BtrfsStrategy {
         &self,
         path: &Path,
         progress: &mut dyn FnMut(InitProgress),
-    ) -> Result<bool> {
+    ) -> Result<StrategyInit> {
         initialize_directory_linux(path, progress)
     }
 
@@ -41,7 +41,7 @@ fn copy_directory_linux(from: &Path, to: &Path) -> Result<()> {
 fn initialize_directory_linux(
     path: &Path,
     progress: &mut dyn FnMut(InitProgress),
-) -> Result<bool> {
+) -> Result<StrategyInit> {
     if !is_btrfs_filesystem(path)? {
         return Err(Error::CowUnavailable(format!(
             "{} is not on a btrfs filesystem",
@@ -49,7 +49,7 @@ fn initialize_directory_linux(
         )));
     }
     if is_btrfs_subvolume(path)? {
-        return Ok(false);
+        return Ok(StrategyInit::AlreadyNative);
     }
 
     let parent = path
@@ -88,7 +88,7 @@ fn initialize_directory_linux(
                 "initialized workspace is active but failed to remove the original directory: {error}"
             ))
         })?;
-        Ok(true)
+        Ok(StrategyInit::Converted)
     })();
     if result.is_err() && staging.exists() {
         let _ = remove_directory_linux(&staging);
@@ -526,7 +526,10 @@ mod linux_tests {
         std::os::unix::fs::symlink("file.txt", nested.join("link.txt")).unwrap();
         let mut progress = Vec::new();
 
-        assert!(initialize_directory_linux(&source, &mut |event| progress.push(event)).unwrap());
+        assert_eq!(
+            initialize_directory_linux(&source, &mut |event| progress.push(event)).unwrap(),
+            StrategyInit::Converted
+        );
         assert!(is_btrfs_subvolume(&source).unwrap());
         assert_eq!(
             fs::read_to_string(source.join("nested/file.txt")).unwrap(),

--- a/crates/core/src/strategy/mod.rs
+++ b/crates/core/src/strategy/mod.rs
@@ -16,14 +16,21 @@ pub(crate) trait Strategy {
         &self,
         _path: &Path,
         _progress: &mut dyn FnMut(InitProgress),
-    ) -> Result<bool> {
-        Ok(false)
+    ) -> Result<StrategyInit> {
+        Ok(StrategyInit::AlreadyNative)
     }
 
     fn remove_directory(&self, path: &Path) -> Result<()> {
         fs::remove_dir_all(path)?;
         Ok(())
     }
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StrategyInit {
+    AlreadyNative,
+    Converted,
 }
 
 pub(crate) fn default_strategy() -> Box<dyn Strategy> {

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -136,7 +136,7 @@ fn execute(input: &str) -> Result<Value, Failure> {
     }
 }
 
-fn response(input: *const c_char) -> Response {
+unsafe fn response(input: *const c_char) -> Response {
     if input.is_null() {
         return Response::Error {
             error: Failure::protocol(
@@ -145,6 +145,8 @@ fn response(input: *const c_char) -> Response {
             ),
         };
     }
+    // SAFETY: null was checked above. The caller promises any non-null input
+    // points to a valid null-terminated request buffer for this call.
     let input = unsafe { CStr::from_ptr(input) };
     match input.to_str() {
         Ok(input) => match execute(input) {
@@ -157,20 +159,44 @@ fn response(input: *const c_char) -> Response {
     }
 }
 
+/// # Safety
+///
+/// If `input` is non-null, it must point to a valid null-terminated byte
+/// buffer for the duration of this call.
 #[unsafe(no_mangle)]
-pub extern "C" fn rift_ffi_call(input: *const c_char) -> *mut c_char {
-    let response =
-        std::panic::catch_unwind(|| response(input)).unwrap_or_else(|_| Response::Error {
-            error: Failure::protocol("panic", "rift FFI call panicked".into()),
-        });
-    let output = serde_json::to_string(&response)
-        .unwrap_or_else(|error| format!("{{\"status\":\"error\",\"error\":{{\"code\":\"serialization\",\"message\":\"{error}\"}}}}"));
-    CString::new(output).unwrap().into_raw()
+pub unsafe extern "C" fn rift_ffi_call(input: *const c_char) -> *mut c_char {
+    let response = std::panic::catch_unwind(|| {
+        // SAFETY: forwarded from `rift_ffi_call`'s caller contract.
+        unsafe { response(input) }
+    })
+    .unwrap_or_else(|_| Response::Error {
+        error: Failure::protocol("panic", "rift FFI call panicked".into()),
+    });
+    let output = serde_json::to_string(&response).unwrap_or_else(|_| {
+        r#"{"status":"error","error":{"code":"serialization","message":"failed to serialize response"}}"#
+            .to_owned()
+    });
+    response_string_into_raw(output)
 }
 
+fn response_string_into_raw(output: String) -> *mut c_char {
+    match CString::new(output) {
+        Ok(output) => output.into_raw(),
+        Err(_) => c"{\"status\":\"error\",\"error\":{\"code\":\"serialization\",\"message\":\"response contained an interior null byte\"}}"
+            .to_owned()
+            .into_raw(),
+    }
+}
+
+/// # Safety
+///
+/// `output` must be a pointer previously returned by `rift_ffi_call` that has
+/// not already been freed.
 #[unsafe(no_mangle)]
-pub extern "C" fn rift_ffi_free(output: *mut c_char) {
+pub unsafe extern "C" fn rift_ffi_free(output: *mut c_char) {
     if !output.is_null() {
+        // SAFETY: the caller promises `output` came from `CString::into_raw`
+        // in `rift_ffi_call`, and this function takes back ownership once.
         unsafe {
             drop(CString::from_raw(output));
         }
@@ -195,5 +221,21 @@ mod tests {
             "workspace is not initialized: /tmp/app"
         );
         assert_eq!(response["error"]["path"], "/tmp/app");
+    }
+
+    #[test]
+    fn ffi_response_allocation_handles_interior_nulls() {
+        let output = response_string_into_raw("bad\0json".into());
+        // SAFETY: `response_string_into_raw` returns a valid C string pointer
+        // that remains allocated until `rift_ffi_free` takes it back below.
+        let response = unsafe { CStr::from_ptr(output).to_string_lossy().into_owned() };
+
+        assert!(response.contains("interior null byte"));
+
+        // SAFETY: `output` came from `response_string_into_raw` and has not
+        // been freed yet.
+        unsafe {
+            rift_ffi_free(output);
+        }
     }
 }

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -100,11 +100,10 @@ impl From<Error> for Failure {
 fn execute(input: &str) -> Result<Value, Failure> {
     let request: Request = serde_json::from_str(input)
         .map_err(|error| Failure::protocol("invalid_request", error.to_string()))?;
-    let mut manager = match request.database {
-        Some(path) => Manager::open(path),
-        None => Manager::open_default(),
-    }
-    .map_err(Failure::from)?;
+    let mut manager = request
+        .database
+        .map_or_else(Manager::open_default, Manager::open)
+        .map_err(Failure::from)?;
     match request.command {
         Command::Init { at } => manager
             .init(at)


### PR DESCRIPTION
- extract registry, marker, id, and name concerns from the manager
- replace raw booleans with structured init, git, strategy, and metadata states
- harden ffi c-string handling and unsafe boundaries
- make selected fallible flows more expression-oriented
