### PR TITLE
bench: add create performance research workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,8 @@ dependencies = [
  "libc",
  "rand",
  "rusqlite",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "ulid",

--- a/README.md
+++ b/README.md
@@ -147,6 +147,37 @@ cargo test --workspace --locked
 
 `scripts/install.sh` installs an optimized CLI binary to `${CARGO_HOME:-$HOME/.cargo}/bin/rift`.
 
+### Benchmark
+
+Benchmark a single real `rift create` operation against a directory:
+
+```bash
+cargo bench --bench create -- /path/to/linux
+```
+
+The benchmark initializes the supplied directory before timing, times only creation of the new rift, and then removes the created workspace outside the measured interval. On first use, initialization of an ordinary Linux btrfs directory converts it into a subvolume before measurement. The benchmark uses the production filesystem strategy, so results on macOS measure APFS cloning and results on Linux require and measure btrfs snapshots.
+
+Establish a baseline by measuring multiple independent rift creations and writing an aggregate machine-readable result file. Keep results outside the source workspace so they do not alter future measurements:
+
+```bash
+cargo bench --bench create -- /path/to/linux --samples 10 --output /path/to/results/baseline.json
+```
+
+The JSON result includes each timing sample and the median, minimum, and maximum elapsed time. A future experiment loop can run the same command in candidate workspaces and compare their median results to this baseline.
+
+Compare multiple candidate `rift` code workspaces that contain this benchmark target:
+
+```bash
+cargo bench --bench compare -- /path/to/linux \
+  --candidate /path/to/rift-baseline \
+  --candidate /path/to/rift-candidate-a \
+  --candidate /path/to/rift-candidate-b \
+  --samples 10 \
+  --output /path/to/results/create-run-01
+```
+
+The comparison runner invokes each candidate's optimized `create` benchmark against the same workload, writes `candidate-01.json`, `candidate-02.json`, and so on, then writes `summary.json` with candidates ranked by median creation time. Include the unchanged workspace as one candidate when you need a baseline in the ranking.
+
 ## License
 
 MIT

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,4 +14,14 @@ ulid.workspace = true
 walkdir.workspace = true
 
 [dev-dependencies]
+serde.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
+
+[[bench]]
+name = "create"
+harness = false
+
+[[bench]]
+name = "compare"
+harness = false

--- a/crates/core/benches/AUTORESEARCH.md
+++ b/crates/core/benches/AUTORESEARCH.md
@@ -1,0 +1,220 @@
+# Auto-Research Workflow For `rift create`
+
+This workflow measures attempts to improve `rift create` performance against one large real workload, such as a Linux source checkout. The base checkout named `rift` remains unchanged, runs the comparison, and serves as the baseline. Experimental sibling workspaces named `rift-*` begin from that revision and receive different implementation ideas.
+
+## What Exists
+
+`create.rs` measures the production `Manager::create` path for one Rift implementation:
+
+```bash
+cargo bench --bench create -- /path/to/linux --samples 10 --output /path/to/result.json
+```
+
+`compare.rs` runs that benchmark for multiple Rift implementation checkouts and ranks them by median elapsed time:
+
+```bash
+cargo bench --bench compare -- /path/to/linux \
+  --candidate /path/to/rift \
+  --candidate /path/to/rift-git \
+  --candidate /path/to/rift-registry \
+  --samples 10 \
+  --output /path/to/results/round-01
+```
+
+## Requirements
+
+- Keep the base `/path/to/rift` checkout unchanged; run the comparison command from there and include it as the baseline candidate.
+- Every candidate checkout must contain the `create` benchmark target and its dependencies. Create candidates from a revision containing this benchmark framework.
+- All candidates should begin from the same Git revision before experimental changes are made.
+- Name experimental sibling checkouts `rift-*`, such as `rift-git` or `rift-registry`.
+- Use one workload directory for every candidate in a comparison round.
+- Store output outside the workload directory and outside candidate checkouts.
+- On Linux, the workload must be on a supported btrfs filesystem for production snapshot behavior.
+- On macOS, results measure APFS `clonefile`, not btrfs behavior.
+
+The benchmark initializes the workload before timing. On the first run on Linux, initialization of an ordinary btrfs directory may convert it into a subvolume before any measured samples are taken. It leaves the workload initialized for later rounds.
+
+## Setup
+
+First commit or otherwise preserve the benchmark framework in the base `rift` checkout, then create isolated candidate code workspaces from that same revision. A useful first-round layout is:
+
+```text
+/path/to/rift                unchanged baseline and benchmark runner
+/path/to/rift-git            one Git-path hypothesis
+/path/to/rift-registry       one registry hypothesis
+/path/to/rift-strategy       one filesystem-strategy hypothesis
+/path/to/rift-other          one additional measured idea
+/path/to/linux               workload checkout
+/path/to/results             benchmark evidence, outside all checkouts
+```
+
+The candidate suffixes are suggestions only. Each `rift-*` experimental candidate should test one clearly stated idea, so measured results can be attributed to a specific change.
+
+For example, after the benchmark framework has been committed in the base checkout, create the experimental candidates with Rift itself:
+
+```bash
+cd /path/to/rift
+rift init --here .
+rift create --name rift-git --into /path/to
+rift create --name rift-registry --into /path/to
+rift create --name rift-strategy --into /path/to
+rift create --name rift-other --into /path/to
+```
+
+Use `/path/to/rift` as the unchanged baseline and give the printed `rift-*` candidate paths to the agent for experimental changes. If Rift's storage configuration produces different locations than the example paths, use the paths printed by `rift create`.
+
+## Establish A Baseline
+
+Before changing candidate code, run the unchanged baseline alone:
+
+```bash
+mkdir -p /path/to/results/baseline
+cd /path/to/rift
+cargo bench --bench create -- /path/to/linux \
+  --samples 10 \
+  --output /path/to/results/baseline/create.json
+```
+
+The JSON result contains:
+
+```json
+{
+  "benchmark": "create",
+  "platform": "macos",
+  "source": "/path/to/linux",
+  "samples_ms": [37.8, 38.1, 37.6],
+  "median_ms": 37.8,
+  "min_ms": 37.6,
+  "max_ms": 38.1,
+  "cleanup_passed": true
+}
+```
+
+Use `median_ms` as the initial comparison metric. Keep the raw samples to identify noisy results.
+
+## Run An Auto-Research Round
+
+Give the agent a workload, a fixed baseline candidate, experimental candidates, and a measurement budget. For example:
+
+```text
+Run an auto-research round to reduce median `rift create` time without breaking correctness.
+
+Baseline and runner: /path/to/rift
+Workload: /path/to/linux
+Results: /path/to/results/round-01
+Candidates:
+- /path/to/rift-git
+- /path/to/rift-registry
+- /path/to/rift-strategy
+- /path/to/rift-other
+Samples per candidate: 10
+Rounds: 1
+
+Keep `/path/to/rift` unchanged and include it as the baseline in every comparison. Use one distinct hypothesis per `rift-*` candidate. Run `cargo test --workspace --locked` in every changed candidate before benchmarking. Exclude failing candidates. Run the comparison benchmark, inspect `summary.json`, and report the measured winner, patch summary, risks, and recommended next round.
+```
+
+For each experimental candidate, the agent should:
+
+1. Inspect the current implementation path relevant to its hypothesis.
+2. Make only the candidate-specific code change.
+3. Run correctness verification inside that candidate:
+
+```bash
+cargo test --workspace --locked
+```
+
+4. Preserve the candidate if it passes, or mark it failed and exclude it from the comparison command.
+
+After implementation and tests, execute the comparison from the unchanged base checkout:
+
+```bash
+cd /path/to/rift
+cargo bench --bench compare -- /path/to/linux \
+  --candidate /path/to/rift \
+  --candidate /path/to/rift-git \
+  --candidate /path/to/rift-registry \
+  --candidate /path/to/rift-strategy \
+  --candidate /path/to/rift-other \
+  --samples 10 \
+  --output /path/to/results/round-01
+```
+
+Remove any candidate from this invocation if its tests failed.
+
+## Results
+
+The comparison output directory contains:
+
+```text
+/path/to/results/round-01/
+  candidate-01.json
+  candidate-02.json
+  candidate-03.json
+  candidate-04.json
+  candidate-05.json
+  summary.json
+```
+
+`candidate-NN.json` contains the raw samples and aggregate timings from one candidate. `summary.json` maps each result back to its candidate checkout and ranks all included candidates by `median_ms`:
+
+```json
+{
+  "benchmark": "create",
+  "source": "/path/to/linux",
+  "samples": 10,
+  "candidates": [
+    {
+      "rank": 1,
+      "candidate": "/path/to/rift-registry",
+      "result": "/path/to/results/round-01/candidate-03.json",
+      "median_ms": 34.9,
+      "min_ms": 34.1,
+      "max_ms": 36.0,
+      "difference_from_fastest_percent": 0.0
+    },
+    {
+      "rank": 2,
+      "candidate": "/path/to/rift",
+      "result": "/path/to/results/round-01/candidate-01.json",
+      "median_ms": 39.4,
+      "min_ms": 38.8,
+      "max_ms": 40.6,
+      "difference_from_fastest_percent": 12.9
+    }
+  ]
+}
+```
+
+## Decision Rules
+
+Use these rules when choosing what to do next:
+
+1. Reject any candidate whose required tests fail.
+2. Reject benchmark results where cleanup fails.
+3. Prefer candidates with a lower `median_ms` than the unchanged `/path/to/rift` baseline.
+4. Treat very small differences as inconclusive when their raw samples overlap substantially; rerun finalists with more samples.
+5. Inspect code risk and scope before promoting a timing winner.
+6. If two winning changes are independent, combine them in a fresh `rift-*` candidate created from `/path/to/rift`, then benchmark the combined candidate against each individual winner and `/path/to/rift`.
+7. Keep each round's results directory unchanged as experiment evidence.
+
+## Follow-Up Round
+
+After a first round, create a new results directory and compare the most promising paths again. For example:
+
+```bash
+cd /path/to/rift
+cargo bench --bench compare -- /path/to/linux \
+  --candidate /path/to/rift \
+  --candidate /path/to/rift-registry \
+  --candidate /path/to/rift-combined \
+  --samples 30 \
+  --output /path/to/results/round-02-finalists
+```
+
+Use higher sample counts for finalists rather than spending that budget on clearly unsuccessful first-round candidates.
+
+## Current Boundaries
+
+The benchmark framework handles measurement, JSON result persistence, and candidate ranking. The agent currently handles hypothesis selection, parallel code changes, correctness checks, candidate exclusion, result review, and decisions about combining or continuing experiments.
+
+This is sufficient for measured auto-research rounds. Automate more orchestration only after several rounds reveal repetitive work worth encoding.

--- a/crates/core/benches/compare.rs
+++ b/crates/core/benches/compare.rs
@@ -1,0 +1,183 @@
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Deserialize)]
+struct BenchmarkResult {
+    median_ms: f64,
+    min_ms: f64,
+    max_ms: f64,
+    cleanup_passed: bool,
+}
+
+#[derive(Serialize)]
+struct ComparisonResult {
+    benchmark: &'static str,
+    timestamp_ms: u128,
+    platform: &'static str,
+    source: PathBuf,
+    samples: usize,
+    candidates: Vec<CandidateResult>,
+}
+
+#[derive(Serialize)]
+struct CandidateResult {
+    rank: usize,
+    candidate: PathBuf,
+    result: PathBuf,
+    median_ms: f64,
+    min_ms: f64,
+    max_ms: f64,
+    difference_from_fastest_percent: f64,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("comparison failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut arguments = env::args_os()
+        .skip(1)
+        .filter(|argument| argument.as_os_str() != OsStr::new("--bench"));
+    let mut source = None;
+    let mut output = None;
+    let mut samples = 10;
+    let mut candidates = Vec::new();
+    while let Some(argument) = arguments.next() {
+        if argument == OsStr::new("--output") {
+            if output.is_some() {
+                return Err("the comparison accepts only one --output directory".into());
+            }
+            output = Some(
+                arguments
+                    .next()
+                    .map(PathBuf::from)
+                    .ok_or("--output requires a directory path")?,
+            );
+            continue;
+        }
+        if argument == OsStr::new("--samples") {
+            let value = arguments.next().ok_or("--samples requires a count")?;
+            samples = value
+                .to_str()
+                .ok_or("--samples requires a UTF-8 integer")?
+                .parse::<usize>()?;
+            if samples == 0 {
+                return Err("--samples must be greater than zero".into());
+            }
+            continue;
+        }
+        if argument == OsStr::new("--candidate") {
+            candidates.push(
+                arguments
+                    .next()
+                    .map(PathBuf::from)
+                    .ok_or("--candidate requires a repository path")?,
+            );
+            continue;
+        }
+        if source.is_some() {
+            return Err("the comparison accepts exactly one workload directory".into());
+        }
+        source = Some(PathBuf::from(argument));
+    }
+    let source = source.ok_or(
+        "usage: cargo bench --bench compare -- /path/to/workload --candidate /path/to/rift [--candidate /path/to/candidate] --output /path/to/results [--samples N]",
+    )?;
+    let output = output.ok_or("--output is required for comparison results")?;
+    if candidates.is_empty() {
+        return Err("provide at least one candidate repository with --candidate".into());
+    }
+
+    let source = fs::canonicalize(source)?;
+    fs::create_dir_all(&output)?;
+    let output = fs::canonicalize(output)?;
+    let mut measured = Vec::with_capacity(candidates.len());
+    for (index, candidate) in candidates.into_iter().enumerate() {
+        let candidate = fs::canonicalize(candidate)?;
+        if !candidate.join("Cargo.toml").exists() {
+            return Err(format!(
+                "candidate is not a Cargo workspace: {}",
+                candidate.display()
+            )
+            .into());
+        }
+        let result_path = output.join(format!("candidate-{:02}.json", index + 1));
+        run_candidate(&candidate, &source, samples, &result_path)?;
+        let result: BenchmarkResult = serde_json::from_slice(&fs::read(&result_path)?)?;
+        if !result.cleanup_passed {
+            return Err(format!(
+                "candidate did not clean up its rifts: {}",
+                candidate.display()
+            )
+            .into());
+        }
+        measured.push(CandidateResult {
+            rank: 0,
+            candidate,
+            result: result_path,
+            median_ms: result.median_ms,
+            min_ms: result.min_ms,
+            max_ms: result.max_ms,
+            difference_from_fastest_percent: 0.0,
+        });
+    }
+
+    measured.sort_by(|left, right| left.median_ms.total_cmp(&right.median_ms));
+    let fastest = measured[0].median_ms;
+    for (index, candidate) in measured.iter_mut().enumerate() {
+        candidate.rank = index + 1;
+        candidate.difference_from_fastest_percent = (candidate.median_ms / fastest - 1.0) * 100.0;
+        println!(
+            "{}\t{:.3} ms\t+{:.2}%\t{}",
+            candidate.rank,
+            candidate.median_ms,
+            candidate.difference_from_fastest_percent,
+            candidate.candidate.display()
+        );
+    }
+
+    let summary = ComparisonResult {
+        benchmark: "create",
+        timestamp_ms: SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+        platform: env::consts::OS,
+        source,
+        samples,
+        candidates: measured,
+    };
+    let summary_path = output.join("summary.json");
+    fs::write(
+        &summary_path,
+        serde_json::to_string_pretty(&summary)? + "\n",
+    )?;
+    println!("summary\t{}", summary_path.display());
+    Ok(())
+}
+
+fn run_candidate(
+    candidate: &Path,
+    source: &Path,
+    samples: usize,
+    output: &Path,
+) -> Result<(), Box<dyn Error>> {
+    println!("running\t{}", candidate.display());
+    let status = Command::new("cargo")
+        .current_dir(candidate)
+        .args(["bench", "--locked", "--bench", "create", "--"])
+        .arg(source)
+        .args(["--samples", &samples.to_string(), "--output"])
+        .arg(output)
+        .status()?;
+    if !status.success() {
+        return Err(format!("candidate benchmark failed: {}", candidate.display()).into());
+    }
+    Ok(())
+}

--- a/crates/core/benches/create.rs
+++ b/crates/core/benches/create.rs
@@ -1,0 +1,123 @@
+use rift::{Create, Manager};
+use serde::Serialize;
+use std::env;
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+#[derive(Serialize)]
+struct BenchmarkResult {
+    benchmark: &'static str,
+    timestamp_ms: u128,
+    platform: &'static str,
+    source: PathBuf,
+    samples_ms: Vec<f64>,
+    median_ms: f64,
+    min_ms: f64,
+    max_ms: f64,
+    cleanup_passed: bool,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("benchmark failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut arguments = env::args_os()
+        .skip(1)
+        .filter(|argument| argument.as_os_str() != OsStr::new("--bench"));
+    let mut source = None;
+    let mut output = None;
+    let mut samples = 1;
+    while let Some(argument) = arguments.next() {
+        if argument == OsStr::new("--output") {
+            if output.is_some() {
+                return Err("the create benchmark accepts only one --output path".into());
+            }
+            output = Some(
+                arguments
+                    .next()
+                    .map(PathBuf::from)
+                    .ok_or("--output requires a file path")?,
+            );
+            continue;
+        }
+        if argument == OsStr::new("--samples") {
+            let value = arguments.next().ok_or("--samples requires a count")?;
+            samples = value
+                .to_str()
+                .ok_or("--samples requires a UTF-8 integer")?
+                .parse::<usize>()?;
+            if samples == 0 {
+                return Err("--samples must be greater than zero".into());
+            }
+            continue;
+        }
+        if source.is_some() {
+            return Err("the create benchmark accepts exactly one workspace directory".into());
+        }
+        source = Some(PathBuf::from(argument));
+    }
+    let source = source.ok_or(
+        "usage: cargo bench --bench create -- /path/to/workspace [--samples N] [--output /path/to/result.json]",
+    )?;
+
+    let mut manager = Manager::open_default()?;
+    manager.init(&source)?;
+    let source = fs::canonicalize(source)?;
+
+    let mut samples_ms = Vec::with_capacity(samples);
+    for sample in 1..=samples {
+        let started = Instant::now();
+        let destination = manager.create(Create {
+            from: source.clone(),
+            name: None,
+            into: None,
+        })?;
+        let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
+
+        println!(
+            "create\t{sample}/{samples}\t{elapsed_ms:.3} ms\t{}",
+            destination.display()
+        );
+
+        manager.remove(&destination)?;
+        manager.gc()?;
+        samples_ms.push(elapsed_ms);
+    }
+
+    let mut sorted = samples_ms.clone();
+    sorted.sort_by(f64::total_cmp);
+    let median_ms = if samples % 2 == 0 {
+        (sorted[samples / 2 - 1] + sorted[samples / 2]) / 2.0
+    } else {
+        sorted[samples / 2]
+    };
+    let min_ms = sorted[0];
+    let max_ms = sorted[samples - 1];
+
+    if samples > 1 {
+        println!("median\t{median_ms:.3} ms\tmin {min_ms:.3} ms\tmax {max_ms:.3} ms");
+    }
+
+    if let Some(output) = output {
+        let result = BenchmarkResult {
+            benchmark: "create",
+            timestamp_ms: SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+            platform: env::consts::OS,
+            source,
+            samples_ms,
+            median_ms,
+            min_ms,
+            max_ms,
+            cleanup_passed: true,
+        };
+        fs::write(output, serde_json::to_string_pretty(&result)? + "\n")?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a `create` benchmark for repeated real `rift create` measurements with JSON output
- add a `compare` benchmark to rank baseline and candidate Rift checkouts by median time
- document the auto-research workflow for running and evaluating candidate experiments

## Testing
- `cargo fmt --check`
- `cargo test --workspace --locked`
- `cargo bench --bench create --no-run --locked`
- `cargo bench --bench compare --no-run --locked`
- `RIFT_REQUIRE_APFS_TESTS=1 cargo test --package rift --locked`
- smoke-tested aggregate benchmark and candidate comparison output on temporary APFS workspaces