### PR TITLE
feat(core): add XFS reflink support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,33 @@ jobs:
           RIFT_REQUIRE_BTRFS_TESTS: "1"
         run: cargo test --package rift --locked
 
+  xfs-test:
+    name: XFS integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Create XFS workspace image
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes xfsprogs
+          truncate -s 1G "$RUNNER_TEMP/rift-xfs.img"
+          mkfs.xfs -f -m reflink=1 "$RUNNER_TEMP/rift-xfs.img"
+          sudo mkdir -p /mnt/rift-xfs
+          sudo mount -o loop "$RUNNER_TEMP/rift-xfs.img" /mnt/rift-xfs
+          sudo chown "$USER:$USER" /mnt/rift-xfs
+          cp -a "$GITHUB_WORKSPACE/." /mnt/rift-xfs/rift
+
+      - name: Run tests on XFS
+        working-directory: /mnt/rift-xfs/rift
+        env:
+          RIFT_REQUIRE_XFS_TESTS: "1"
+        run: cargo test --package rift --locked
+
   apfs-test:
     name: APFS integration tests
     runs-on: macos-14

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ rift: better alternative to git worktrees
 - fast cli
 - use as FFI lib with bun or node
 
-mac and linux+btrfs for now
+mac and linux with btrfs or reflink-enabled XFS for now
 more support soon
 
 ## Install
@@ -24,11 +24,12 @@ Release archives are available from [GitHub Releases](https://github.com/anomaly
 
 ## Platforms
 
-| Platform          | Backend                  | Behavior                                                           |
-| ----------------- | ------------------------ | ------------------------------------------------------------------ |
-| Linux x64         | Writable btrfs snapshots | `rift init` converts an ordinary directory into a btrfs subvolume. |
-| macOS arm64 / x64 | APFS `clonefile`         | `rift init` registers the source directory.                        |
-| Windows x64       | None                     | The package is published; workspace creation is not implemented.   |
+| Platform          | Backend                    | Behavior                                                           |
+| ----------------- | -------------------------- | ------------------------------------------------------------------ |
+| Linux x64         | Writable btrfs snapshots   | `rift init` converts an ordinary directory into a btrfs subvolume. |
+| Linux x64         | XFS per-file reflinks      | `rift init` verifies reflink support and registers the directory.  |
+| macOS arm64 / x64 | APFS `clonefile`           | `rift init` registers the source directory.                        |
+| Windows x64       | None                       | The package is published; workspace creation is not implemented.   |
 
 ## CLI
 
@@ -41,7 +42,7 @@ rift init
 
 `rift init` selects an existing Rift root above the current directory, or the nearest Git root when no Rift root exists. Use `--here` to initialize exactly the selected directory.
 
-On Linux, first initialization of an ordinary btrfs directory performs a reflink import into a new btrfs subvolume and swaps it into the same path. If the selected root is registered already, no conversion occurs. If its `.rift` marker is missing, `rift init` restores it and completes any required conversion.
+On Linux, first initialization of an ordinary btrfs directory performs a reflink import into a new btrfs subvolume and swaps it into the same path. On XFS, initialization verifies that the filesystem supports reflinks and registers the directory in place. If the selected root is registered already, no conversion occurs. If its `.rift` marker is missing, `rift init` restores it and completes any required setup.
 
 ### Create
 
@@ -53,7 +54,7 @@ rift create --into /fast/rifts
 
 `rift create` searches upward for `.rift`, copies that managed workspace, records the immediate parent, and prints the new workspace path to stdout.
 
-On Linux, it creates a writable btrfs snapshot. On macOS, it uses APFS `clonefile`.
+On btrfs, it creates a writable subvolume snapshot. On XFS, it reflink-clones the directory tree. On macOS, it uses APFS `clonefile`.
 
 When the workspace is a Git repository, the new workspace has detached `HEAD` and retains index and working-tree state.
 
@@ -155,7 +156,7 @@ Benchmark a single real `rift create` operation against a directory:
 cargo bench --bench create -- /path/to/linux
 ```
 
-The benchmark initializes the supplied directory before timing, times only creation of the new rift, and then removes the created workspace outside the measured interval. On first use, initialization of an ordinary Linux btrfs directory converts it into a subvolume before measurement. The benchmark uses the production filesystem strategy, so results on macOS measure APFS cloning and results on Linux require and measure btrfs snapshots.
+The benchmark initializes the supplied directory before timing, times only creation of the new rift, and then removes the created workspace outside the measured interval. On first use, initialization of an ordinary Linux btrfs directory converts it into a subvolume before measurement. The benchmark uses the production filesystem strategy, so results measure APFS cloning on macOS, btrfs snapshots on btrfs, and per-file reflinks on XFS.
 
 Establish a baseline by measuring multiple independent rift creations and writing an aggregate machine-readable result file. Keep results outside the source workspace so they do not alter future measurements:
 

--- a/crates/core/benches/AUTORESEARCH.md
+++ b/crates/core/benches/AUTORESEARCH.md
@@ -29,10 +29,10 @@ cargo bench --bench compare -- /path/to/linux \
 - Name experimental sibling checkouts `rift-*`, such as `rift-git` or `rift-registry`.
 - Use one workload directory for every candidate in a comparison round.
 - Store output outside the workload directory and outside candidate checkouts.
-- On Linux, the workload must be on a supported btrfs filesystem for production snapshot behavior.
-- On macOS, results measure APFS `clonefile`, not btrfs behavior.
+- On Linux, the workload must be on supported btrfs or reflink-enabled XFS storage for production copy-on-write behavior.
+- On macOS, results measure APFS `clonefile`, not either Linux filesystem backend.
 
-The benchmark initializes the workload before timing. On the first run on Linux, initialization of an ordinary btrfs directory may convert it into a subvolume before any measured samples are taken. It leaves the workload initialized for later rounds.
+The benchmark initializes the workload before timing. On the first run on Linux, initialization of an ordinary btrfs directory may convert it into a subvolume before any measured samples are taken. XFS initialization verifies reflink support without conversion. It leaves the workload initialized for later rounds.
 
 ## Setup
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,7 +27,7 @@ pub enum Error {
     Path(String),
     #[error("copy-on-write cloning unavailable: {0}")]
     CowUnavailable(String),
-    #[error("workspace is not a btrfs subvolume: {0}")]
+    #[error("workspace requires initialization: {0}")]
     InitializationRequired(PathBuf),
     #[error("workspace is not initialized: {0}")]
     WorkspaceNotInitialized(PathBuf),

--- a/crates/core/src/strategy/btrfs.rs
+++ b/crates/core/src/strategy/btrfs.rs
@@ -1,8 +1,11 @@
+use super::linux::{Filesystem, filesystem};
+#[cfg(test)]
+use super::reflink::c_path;
+use super::reflink::{MetadataTarget, copy_metadata_linux, import_directory_linux};
 use super::{Strategy, StrategyInit};
 use crate::{Error, InitProgress, Result};
 use std::fs;
 use std::path::Path;
-use walkdir::WalkDir;
 
 pub(super) struct BtrfsStrategy;
 
@@ -97,199 +100,6 @@ fn initialize_directory_linux(
 }
 
 #[cfg(target_os = "linux")]
-fn import_directory_linux(
-    from: &Path,
-    to: &Path,
-    progress: &mut dyn FnMut(InitProgress),
-) -> Result<()> {
-    use std::collections::HashMap;
-    use std::os::unix::fs::MetadataExt;
-
-    let mut hard_links = HashMap::new();
-    let mut directories = Vec::new();
-    let mut entries = 0;
-    for entry in WalkDir::new(from).min_depth(1).follow_links(false) {
-        let entry = entry?;
-        let source = entry.path();
-        let destination = to.join(
-            source
-                .strip_prefix(from)
-                .map_err(|error| Error::Path(error.to_string()))?,
-        );
-        let metadata = fs::symlink_metadata(source)?;
-        let file_type = metadata.file_type();
-        if file_type.is_dir() {
-            fs::create_dir(&destination)?;
-            directories.push((source.to_path_buf(), destination));
-        } else if file_type.is_file() {
-            let key = (metadata.dev(), metadata.ino());
-            if metadata.nlink() > 1 {
-                if let Some(existing) = hard_links.get(&key) {
-                    fs::hard_link(existing, &destination)?;
-                } else {
-                    reflink_file_linux(source, &destination)?;
-                    hard_links.insert(key, destination.clone());
-                }
-            } else {
-                reflink_file_linux(source, &destination)?;
-            }
-            copy_metadata_linux(source, &destination, MetadataTarget::FileOrDirectory)?;
-        } else if file_type.is_symlink() {
-            std::os::unix::fs::symlink(fs::read_link(source)?, &destination)?;
-            copy_metadata_linux(source, &destination, MetadataTarget::Symlink)?;
-        } else {
-            return Err(Error::UnsupportedEntry(source.to_path_buf()));
-        }
-        entries += 1;
-        progress(InitProgress::ImportedEntries { entries });
-    }
-    for (source, destination) in directories.into_iter().rev() {
-        copy_metadata_linux(&source, &destination, MetadataTarget::FileOrDirectory)?;
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn reflink_file_linux(from: &Path, to: &Path) -> Result<()> {
-    use std::fs::{File, OpenOptions};
-    use std::os::fd::AsRawFd;
-
-    const FICLONE: libc::c_ulong = 0x4004_9409;
-    let source = File::open(from)?;
-    let destination = OpenOptions::new().write(true).create_new(true).open(to)?;
-    // SAFETY: both file descriptors come from live `File` values, and FICLONE
-    // only reads the source fd while mutating the destination file.
-    if unsafe { libc::ioctl(destination.as_raw_fd(), FICLONE, source.as_raw_fd()) } == 0 {
-        return Ok(());
-    }
-    Err(Error::CowUnavailable(format!(
-        "failed to reflink {}: {}",
-        from.display(),
-        std::io::Error::last_os_error()
-    )))
-}
-
-#[cfg(target_os = "linux")]
-#[derive(Clone, Copy)]
-enum MetadataTarget {
-    FileOrDirectory,
-    Symlink,
-}
-
-#[cfg(target_os = "linux")]
-fn copy_metadata_linux(from: &Path, to: &Path, target: MetadataTarget) -> Result<()> {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
-
-    let metadata = fs::symlink_metadata(from)?;
-    let destination = c_path(to)?;
-    // SAFETY: `destination` is a valid null-terminated path, and uid/gid come
-    // from filesystem metadata for `from`.
-    if unsafe { libc::lchown(destination.as_ptr(), metadata.uid(), metadata.gid()) } != 0 {
-        return Err(std::io::Error::last_os_error().into());
-    }
-    if matches!(target, MetadataTarget::FileOrDirectory) {
-        fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))?;
-    }
-    copy_xattrs_linux(from, to)?;
-    let times = [
-        libc::timespec {
-            tv_sec: metadata.atime(),
-            tv_nsec: metadata.atime_nsec(),
-        },
-        libc::timespec {
-            tv_sec: metadata.mtime(),
-            tv_nsec: metadata.mtime_nsec(),
-        },
-    ];
-    // SAFETY: `destination` is a live C string and `times` contains exactly the
-    // two timestamps expected by `utimensat`.
-    if unsafe {
-        libc::utimensat(
-            libc::AT_FDCWD,
-            destination.as_ptr(),
-            times.as_ptr(),
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
-    } != 0
-    {
-        return Err(std::io::Error::last_os_error().into());
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn copy_xattrs_linux(from: &Path, to: &Path) -> Result<()> {
-    let from = c_path(from)?;
-    let to = c_path(to)?;
-    // SAFETY: `from` is a valid C path. A null buffer with size 0 asks the
-    // kernel for the required list size.
-    let size = unsafe { libc::llistxattr(from.as_ptr(), std::ptr::null_mut(), 0) };
-    if size < 0 {
-        return Err(std::io::Error::last_os_error().into());
-    }
-    let mut names = vec![0_u8; size as usize];
-    // SAFETY: `names` was allocated with the size reported by the previous
-    // `llistxattr` call, and its pointer is valid for writes of that length.
-    if size > 0
-        && unsafe { libc::llistxattr(from.as_ptr(), names.as_mut_ptr().cast(), names.len()) } < 0
-    {
-        return Err(std::io::Error::last_os_error().into());
-    }
-    for name in names
-        .split(|byte| *byte == 0)
-        .filter(|name| !name.is_empty())
-    {
-        let name = std::ffi::CString::new(name)
-            .map_err(|_| Error::Path("extended attribute name contains a null byte".into()))?;
-        // SAFETY: `from` and `name` are valid C strings. A null buffer with
-        // size 0 asks the kernel for this attribute's value length.
-        let size =
-            unsafe { libc::lgetxattr(from.as_ptr(), name.as_ptr(), std::ptr::null_mut(), 0) };
-        if size < 0 {
-            return Err(std::io::Error::last_os_error().into());
-        }
-        let mut value = vec![0_u8; size as usize];
-        // SAFETY: `value` was allocated with the exact size reported by
-        // `lgetxattr`, and the path and attribute name are valid C strings.
-        if size > 0
-            && unsafe {
-                libc::lgetxattr(
-                    from.as_ptr(),
-                    name.as_ptr(),
-                    value.as_mut_ptr().cast(),
-                    value.len(),
-                )
-            } < 0
-        {
-            return Err(std::io::Error::last_os_error().into());
-        }
-        // SAFETY: `to` and `name` are valid C strings, and `value` points to
-        // an initialized byte buffer of the supplied length.
-        if unsafe {
-            libc::lsetxattr(
-                to.as_ptr(),
-                name.as_ptr(),
-                value.as_ptr().cast(),
-                value.len(),
-                0,
-            )
-        } != 0
-        {
-            return Err(std::io::Error::last_os_error().into());
-        }
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn c_path(path: &Path) -> Result<std::ffi::CString> {
-    use std::os::unix::ffi::OsStrExt;
-
-    std::ffi::CString::new(path.as_os_str().as_bytes())
-        .map_err(|_| Error::Path(format!("path contains a null byte: {}", path.display())))
-}
-
-#[cfg(target_os = "linux")]
 fn remove_directory_linux(path: &Path) -> Result<()> {
     if !is_btrfs_subvolume(path)? {
         fs::remove_dir_all(path)?;
@@ -310,21 +120,7 @@ fn is_btrfs_subvolume(path: &Path) -> Result<bool> {
 
 #[cfg(target_os = "linux")]
 fn is_btrfs_filesystem(path: &Path) -> Result<bool> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
-
-    const BTRFS_SUPER_MAGIC: libc::c_long = 0x9123_683e;
-    let path = CString::new(path.as_os_str().as_bytes())
-        .map_err(|_| Error::Path(format!("path contains a null byte: {}", path.display())))?;
-    // SAFETY: `statfs` is a plain C struct; zero initialization is a valid
-    // starting state before the kernel fills it.
-    let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
-    // SAFETY: `path` is a valid C string, and `stat` points to writable memory
-    // for the kernel to initialize.
-    if unsafe { libc::statfs(path.as_ptr(), &mut stat) } != 0 {
-        return Err(std::io::Error::last_os_error().into());
-    }
-    Ok(stat.f_type == BTRFS_SUPER_MAGIC)
+    Ok(matches!(filesystem(path)?, Filesystem::Btrfs))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/core/src/strategy/linux.rs
+++ b/crates/core/src/strategy/linux.rs
@@ -1,0 +1,74 @@
+use super::{Strategy, StrategyInit, btrfs::BtrfsStrategy, xfs::XfsStrategy};
+use crate::{Error, InitProgress, Result};
+use std::fs;
+use std::path::Path;
+
+pub(super) struct LinuxStrategy;
+
+impl Strategy for LinuxStrategy {
+    fn copy_directory(&self, from: &Path, to: &Path) -> Result<()> {
+        match filesystem(from)? {
+            Filesystem::Btrfs => BtrfsStrategy.copy_directory(from, to),
+            Filesystem::Xfs => XfsStrategy.copy_directory(from, to),
+            Filesystem::Other => Err(unsupported_filesystem(from)),
+        }
+    }
+
+    fn initialize_directory(
+        &self,
+        path: &Path,
+        progress: &mut dyn FnMut(InitProgress),
+    ) -> Result<StrategyInit> {
+        match filesystem(path)? {
+            Filesystem::Btrfs => BtrfsStrategy.initialize_directory(path, progress),
+            Filesystem::Xfs => XfsStrategy.initialize_directory(path, progress),
+            Filesystem::Other => Err(unsupported_filesystem(path)),
+        }
+    }
+
+    fn remove_directory(&self, path: &Path) -> Result<()> {
+        match filesystem(path)? {
+            Filesystem::Btrfs => BtrfsStrategy.remove_directory(path),
+            Filesystem::Xfs | Filesystem::Other => {
+                fs::remove_dir_all(path)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+fn unsupported_filesystem(path: &Path) -> Error {
+    Error::CowUnavailable(format!(
+        "{} is not on a supported Linux filesystem (btrfs or XFS with reflinks)",
+        path.display()
+    ))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Filesystem {
+    Btrfs,
+    Xfs,
+    Other,
+}
+
+pub(super) fn filesystem(path: &Path) -> Result<Filesystem> {
+    use std::os::unix::ffi::OsStrExt;
+
+    const BTRFS_SUPER_MAGIC: libc::c_long = 0x9123_683e;
+    const XFS_SUPER_MAGIC: libc::c_long = 0x5846_5342;
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| Error::Path(format!("path contains a null byte: {}", path.display())))?;
+    // SAFETY: `statfs` is a plain C struct; zero initialization is a valid
+    // starting state before the kernel fills it.
+    let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
+    // SAFETY: `path` is a valid C string, and `stat` points to writable memory
+    // for the kernel to initialize.
+    if unsafe { libc::statfs(path.as_ptr(), &mut stat) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(match stat.f_type {
+        BTRFS_SUPER_MAGIC => Filesystem::Btrfs,
+        XFS_SUPER_MAGIC => Filesystem::Xfs,
+        _ => Filesystem::Other,
+    })
+}

--- a/crates/core/src/strategy/mod.rs
+++ b/crates/core/src/strategy/mod.rs
@@ -8,6 +8,12 @@ use std::path::Path;
 mod apfs;
 #[cfg(target_os = "linux")]
 mod btrfs;
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+mod reflink;
+#[cfg(target_os = "linux")]
+mod xfs;
 
 pub(crate) trait Strategy {
     fn copy_directory(&self, from: &Path, to: &Path) -> Result<()>;
@@ -35,7 +41,7 @@ pub(crate) enum StrategyInit {
 
 pub(crate) fn default_strategy() -> Box<dyn Strategy> {
     #[cfg(target_os = "linux")]
-    return Box::new(btrfs::BtrfsStrategy);
+    return Box::new(linux::LinuxStrategy);
 
     #[cfg(target_os = "macos")]
     return Box::new(apfs::ApfsStrategy);

--- a/crates/core/src/strategy/reflink.rs
+++ b/crates/core/src/strategy/reflink.rs
@@ -1,0 +1,200 @@
+use crate::{Error, InitProgress, Result};
+use std::fs;
+use std::path::Path;
+use walkdir::WalkDir;
+
+pub(super) fn clone_directory_linux(from: &Path, to: &Path) -> Result<()> {
+    fs::create_dir(to)?;
+    import_directory_linux(from, to, &mut |_| {})?;
+    copy_metadata_linux(from, to, MetadataTarget::FileOrDirectory)
+}
+
+pub(super) fn import_directory_linux(
+    from: &Path,
+    to: &Path,
+    progress: &mut dyn FnMut(InitProgress),
+) -> Result<()> {
+    use std::collections::HashMap;
+    use std::os::unix::fs::MetadataExt;
+
+    let mut hard_links = HashMap::new();
+    let mut directories = Vec::new();
+    for (entry, entries) in WalkDir::new(from)
+        .min_depth(1)
+        .follow_links(false)
+        .into_iter()
+        .zip(1..)
+    {
+        let entry = entry?;
+        let source = entry.path();
+        let destination = to.join(
+            source
+                .strip_prefix(from)
+                .map_err(|error| Error::Path(error.to_string()))?,
+        );
+        let metadata = fs::symlink_metadata(source)?;
+        let file_type = metadata.file_type();
+        if file_type.is_dir() {
+            fs::create_dir(&destination)?;
+            directories.push((source.to_path_buf(), destination));
+        } else if file_type.is_file() {
+            let key = (metadata.dev(), metadata.ino());
+            if metadata.nlink() > 1 {
+                if let Some(existing) = hard_links.get(&key) {
+                    fs::hard_link(existing, &destination)?;
+                } else {
+                    reflink_file_linux(source, &destination)?;
+                    hard_links.insert(key, destination.clone());
+                }
+            } else {
+                reflink_file_linux(source, &destination)?;
+            }
+            copy_metadata_linux(source, &destination, MetadataTarget::FileOrDirectory)?;
+        } else if file_type.is_symlink() {
+            std::os::unix::fs::symlink(fs::read_link(source)?, &destination)?;
+            copy_metadata_linux(source, &destination, MetadataTarget::Symlink)?;
+        } else {
+            return Err(Error::UnsupportedEntry(source.to_path_buf()));
+        }
+        progress(InitProgress::ImportedEntries { entries });
+    }
+    for (source, destination) in directories.into_iter().rev() {
+        copy_metadata_linux(&source, &destination, MetadataTarget::FileOrDirectory)?;
+    }
+    Ok(())
+}
+
+pub(super) fn reflink_file_linux(from: &Path, to: &Path) -> Result<()> {
+    use std::fs::{File, OpenOptions};
+    use std::os::fd::AsRawFd;
+
+    const FICLONE: libc::c_ulong = 0x4004_9409;
+    let source = File::open(from)?;
+    let destination = OpenOptions::new().write(true).create_new(true).open(to)?;
+    // SAFETY: both file descriptors come from live `File` values, and FICLONE
+    // only reads the source fd while mutating the destination file.
+    if unsafe { libc::ioctl(destination.as_raw_fd(), FICLONE, source.as_raw_fd()) } == 0 {
+        return Ok(());
+    }
+    Err(Error::CowUnavailable(format!(
+        "failed to reflink {}: {}",
+        from.display(),
+        std::io::Error::last_os_error()
+    )))
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum MetadataTarget {
+    FileOrDirectory,
+    Symlink,
+}
+
+pub(super) fn copy_metadata_linux(from: &Path, to: &Path, target: MetadataTarget) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = fs::symlink_metadata(from)?;
+    let destination = c_path(to)?;
+    // SAFETY: `destination` is a valid null-terminated path, and uid/gid come
+    // from filesystem metadata for `from`.
+    if unsafe { libc::lchown(destination.as_ptr(), metadata.uid(), metadata.gid()) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    if matches!(target, MetadataTarget::FileOrDirectory) {
+        fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))?;
+    }
+    copy_xattrs_linux(from, to)?;
+    let times = [
+        libc::timespec {
+            tv_sec: metadata.atime(),
+            tv_nsec: metadata.atime_nsec(),
+        },
+        libc::timespec {
+            tv_sec: metadata.mtime(),
+            tv_nsec: metadata.mtime_nsec(),
+        },
+    ];
+    // SAFETY: `destination` is a live C string and `times` contains exactly the
+    // two timestamps expected by `utimensat`.
+    if unsafe {
+        libc::utimensat(
+            libc::AT_FDCWD,
+            destination.as_ptr(),
+            times.as_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+fn copy_xattrs_linux(from: &Path, to: &Path) -> Result<()> {
+    let from = c_path(from)?;
+    let to = c_path(to)?;
+    // SAFETY: `from` is a valid C path. A null buffer with size 0 asks the
+    // kernel for the required list size.
+    let size = unsafe { libc::llistxattr(from.as_ptr(), std::ptr::null_mut(), 0) };
+    if size < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let mut names = vec![0_u8; size as usize];
+    // SAFETY: `names` was allocated with the size reported by the previous
+    // `llistxattr` call, and its pointer is valid for writes of that length.
+    if size > 0
+        && unsafe { libc::llistxattr(from.as_ptr(), names.as_mut_ptr().cast(), names.len()) } < 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    for name in names
+        .split(|byte| *byte == 0)
+        .filter(|name| !name.is_empty())
+    {
+        let name = std::ffi::CString::new(name)
+            .map_err(|_| Error::Path("extended attribute name contains a null byte".into()))?;
+        // SAFETY: `from` and `name` are valid C strings. A null buffer with
+        // size 0 asks the kernel for this attribute's value length.
+        let size =
+            unsafe { libc::lgetxattr(from.as_ptr(), name.as_ptr(), std::ptr::null_mut(), 0) };
+        if size < 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let mut value = vec![0_u8; size as usize];
+        // SAFETY: `value` was allocated with the exact size reported by
+        // `lgetxattr`, and the path and attribute name are valid C strings.
+        if size > 0
+            && unsafe {
+                libc::lgetxattr(
+                    from.as_ptr(),
+                    name.as_ptr(),
+                    value.as_mut_ptr().cast(),
+                    value.len(),
+                )
+            } < 0
+        {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        // SAFETY: `to` and `name` are valid C strings, and `value` points to
+        // an initialized byte buffer of the supplied length.
+        if unsafe {
+            libc::lsetxattr(
+                to.as_ptr(),
+                name.as_ptr(),
+                value.as_ptr().cast(),
+                value.len(),
+                0,
+            )
+        } != 0
+        {
+            return Err(std::io::Error::last_os_error().into());
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn c_path(path: &Path) -> Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| Error::Path(format!("path contains a null byte: {}", path.display())))
+}

--- a/crates/core/src/strategy/xfs.rs
+++ b/crates/core/src/strategy/xfs.rs
@@ -1,0 +1,173 @@
+use super::linux::{Filesystem, filesystem};
+use super::reflink::{clone_directory_linux, reflink_file_linux};
+use super::{Strategy, StrategyInit};
+use crate::{Error, InitProgress, Result};
+use std::fs;
+use std::path::Path;
+
+pub(super) struct XfsStrategy;
+
+impl Strategy for XfsStrategy {
+    fn copy_directory(&self, from: &Path, to: &Path) -> Result<()> {
+        use std::os::unix::fs::MetadataExt;
+
+        if !is_xfs_filesystem(from)? {
+            return Err(Error::CowUnavailable(format!(
+                "{} is not on an XFS filesystem",
+                from.display()
+            )));
+        }
+        let destination_parent = to
+            .parent()
+            .ok_or_else(|| Error::Path(format!("destination has no parent: {}", to.display())))?;
+        if !is_xfs_filesystem(destination_parent)?
+            || fs::metadata(from)?.dev() != fs::metadata(destination_parent)?.dev()
+        {
+            return Err(Error::CowUnavailable(format!(
+                "XFS reflinks require source and destination on the same filesystem: {}",
+                to.display()
+            )));
+        }
+        clone_directory_linux(from, to)
+    }
+
+    fn initialize_directory(
+        &self,
+        path: &Path,
+        _progress: &mut dyn FnMut(InitProgress),
+    ) -> Result<StrategyInit> {
+        if !is_xfs_filesystem(path)? {
+            return Err(Error::CowUnavailable(format!(
+                "{} is not on an XFS filesystem",
+                path.display()
+            )));
+        }
+        verify_reflinks_linux(path)?;
+        Ok(StrategyInit::AlreadyNative)
+    }
+}
+
+fn is_xfs_filesystem(path: &Path) -> Result<bool> {
+    Ok(matches!(filesystem(path)?, Filesystem::Xfs))
+}
+
+fn verify_reflinks_linux(path: &Path) -> Result<()> {
+    let operation_id = ulid::Ulid::new();
+    let source = path.join(format!(".rift-reflink-probe-{operation_id}"));
+    let destination = path.join(format!(".rift-reflink-probe-copy-{operation_id}"));
+    fs::write(&source, b"rift")?;
+    let result = reflink_file_linux(&source, &destination);
+    let cleanup = [&source, &destination]
+        .into_iter()
+        .filter(|path| path.exists())
+        .try_for_each(fs::remove_file);
+    result.and(cleanup.map_err(Error::from))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::strategy::linux::LinuxStrategy;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    use tempfile::{Builder, TempDir};
+
+    fn xfs_temp() -> Option<TempDir> {
+        let temp = Builder::new()
+            .prefix(".rift-core-test-")
+            .tempdir_in(std::env::current_dir().unwrap())
+            .unwrap();
+        is_xfs_filesystem(temp.path()).unwrap().then_some(temp)
+    }
+
+    #[test]
+    fn xfs_integration_environment_is_available() {
+        if std::env::var_os("RIFT_REQUIRE_XFS_TESTS").is_some() {
+            assert!(
+                xfs_temp().is_some(),
+                "RIFT_REQUIRE_XFS_TESTS requires the checkout filesystem to be XFS"
+            );
+        }
+    }
+
+    #[test]
+    fn native_init_verifies_reflink_support() {
+        let Some(temp) = xfs_temp() else {
+            return;
+        };
+        assert_eq!(
+            LinuxStrategy
+                .initialize_directory(temp.path(), &mut |_| {})
+                .unwrap(),
+            StrategyInit::AlreadyNative
+        );
+    }
+
+    #[test]
+    fn native_copy_preserves_files_links_and_metadata() {
+        let Some(temp) = xfs_temp() else {
+            return;
+        };
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        let nested = source.join("nested");
+        fs::create_dir(&source).unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o750)).unwrap();
+        fs::create_dir(&nested).unwrap();
+        let file = nested.join("file.txt");
+        fs::write(&file, "hello").unwrap();
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o640)).unwrap();
+        fs::hard_link(&file, nested.join("hard.txt")).unwrap();
+        std::os::unix::fs::symlink("file.txt", nested.join("link.txt")).unwrap();
+
+        LinuxStrategy.copy_directory(&source, &destination).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination.join("nested/file.txt")).unwrap(),
+            "hello"
+        );
+        assert_eq!(
+            fs::read_link(destination.join("nested/link.txt")).unwrap(),
+            Path::new("file.txt")
+        );
+        assert_eq!(
+            fs::metadata(destination.join("nested/file.txt"))
+                .unwrap()
+                .ino(),
+            fs::metadata(destination.join("nested/hard.txt"))
+                .unwrap()
+                .ino()
+        );
+        assert_eq!(
+            fs::metadata(destination.join("nested/file.txt"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o640
+        );
+        assert_eq!(
+            fs::metadata(&destination).unwrap().permissions().mode() & 0o777,
+            0o750
+        );
+        LinuxStrategy.remove_directory(&destination).unwrap();
+        assert!(!destination.exists());
+    }
+
+    #[test]
+    fn native_copy_rejects_storage_on_another_filesystem() {
+        let Some(temp) = xfs_temp() else {
+            return;
+        };
+        let source = temp.path().join("source");
+        fs::create_dir(&source).unwrap();
+        let other = TempDir::new().unwrap();
+        if fs::metadata(&source).unwrap().dev() == fs::metadata(other.path()).unwrap().dev() {
+            return;
+        }
+
+        assert!(matches!(
+            LinuxStrategy.copy_directory(&source, &other.path().join("destination")),
+            Err(Error::CowUnavailable(_))
+        ));
+    }
+}

--- a/specs.md
+++ b/specs.md
@@ -2,7 +2,7 @@
 
 ## Requirement
 
-`rift` must be cross-platform as far as practical. Core semantics should work across macOS, Linux, and Windows. On Linux, managed workspaces are btrfs subvolumes so creation uses instantaneous writable snapshots rather than tree traversal.
+`rift` must be cross-platform as far as practical. Core semantics should work across macOS, Linux, and Windows. On Linux, managed workspaces use either btrfs subvolumes for instantaneous writable snapshots or reflink-enabled XFS directories for copy-on-write tree cloning.
 
 ## API
 
@@ -16,9 +16,10 @@ init(input: {
 
 `init` prepares and registers an original workspace for Rift.
 
-- On Linux, `at` must be on btrfs; on other supported systems, initialization registers the workspace without filesystem conversion.
+- On Linux, `at` must be on btrfs or reflink-enabled XFS; on other supported systems, initialization registers the workspace without filesystem conversion.
 - If `at` is already a btrfs subvolume, register it without replacing it.
 - If `at` is an ordinary btrfs directory, reflink-import it once into a staged btrfs subvolume and atomically replace the original directory at its existing path.
+- On XFS, verify reflink support and register `at` without replacing it.
 - The original directory is retained under an internal temporary path only while it is needed for rollback and is removed before a successful `init` returns.
 - The core operation initializes exactly `at` and does not search parent directories.
 - The CLI defaults `at` to the current working directory; by default it selects the nearest existing managed ancestor or nearest Git root, prints the selected path, and then invokes core `init` with that exact path. `--here` opts into selecting exactly the supplied path.
@@ -44,7 +45,7 @@ Default behavior:
 - Detach `HEAD` in the new workspace.
 - Return the path of the new workspace.
 
-On Linux, `from` must already be a btrfs subvolume. If it is an ordinary directory, fail and instruct the user to run `rift init` first.
+On btrfs, `from` must already be a subvolume. If it is an ordinary directory, fail and instruct the user to run `rift init` first. On XFS, clone the directory tree with native per-file reflinks.
 
 If `from` is already managed by Rift, create copies that exact directory. Do not resolve back to an earlier workspace. Metadata should record the immediate source rift as its parent.
 
@@ -113,8 +114,9 @@ gc(): AbsolutePath[]
 
 `gc` physically deletes rifts previously moved into Rift-owned trash and returns deleted trash paths for CLI output.
 
-- On Linux, attempt immediate btrfs subvolume deletion first.
+- On btrfs, attempt immediate subvolume deletion first.
 - If standard mount permissions deny deletion of a populated subvolume, delete its contents and remove the now-empty subvolume with ordinary directory removal.
+- On XFS, recursively remove the reflinked directory tree.
 - Delete each trash registry record after its filesystem directory is successfully removed.
 - Delete active registry records whose filesystem directories were removed outside Rift only when no existing recorded descendant would be orphaned, and include pruned missing paths in the result.
 
@@ -179,7 +181,8 @@ The tool does not create branches, commit changes, or otherwise replace normal G
 Copying is implemented behind a `Strategy` interface so platform-specific copy-on-write backends can be added independently. Each strategy owns initialization, snapshot creation, and removal behavior for its filesystem.
 
 - The `BtrfsStrategy` production strategy on Linux uses writable btrfs subvolume snapshots.
-- Linux `init` performs a native per-file reflink import only when converting an existing ordinary btrfs workspace into a subvolume; it does not spawn an external copy command and may report import progress. `create` never performs file-by-file cloning.
+- The `BtrfsStrategy` performs a native per-file reflink import only when `init` converts an existing ordinary workspace into a subvolume; it does not spawn an external copy command and may report import progress. Its `create` never performs file-by-file cloning.
+- The `XfsStrategy` production strategy on Linux verifies reflink support during `init` and uses native per-file reflinks during `create` without spawning an external copy command.
 - The `ApfsStrategy` production strategy on macOS uses APFS `clonefile` directory cloning.
 - If no implemented copy-on-write strategy succeeds, `create` fails.
 - Full byte copying is not implemented as a fallback.


### PR DESCRIPTION
## summary
- dispatch Linux filesystem operations between btrfs snapshots and reflink-enabled XFS clones
- reuse the native `FICLONE` importer for XFS directory cloning while preserving btrfs behavior
- add loopback XFS integration coverage and document the new backend
