### PR TITLE
Add `--worktrees` flag to register rifts as Git worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ rift init --worktrees
 
 On Linux, first initialization of an ordinary btrfs directory performs a reflink import into a new btrfs subvolume and swaps it into the same path. On XFS, initialization verifies that the filesystem supports reflinks and registers the directory in place. If the selected root is registered already, no conversion occurs. If its `.rift` marker is missing, `rift init` restores it and completes any required setup.
 
-Use `rift init --worktrees` for Git repositories when future rifts should be registered as real Git worktrees. This moves the repository's `.git` directory into Rift's data directory, leaves a `.git` pointer file in the workspace, and makes future rifts share Git refs, objects, and config through that external Git directory. The shared Git storage is named `rift-manager` under Rift's repo storage. Do not delete the Rift data directory for a worktree-initialized repo while its workspaces still exist.
+Use `rift init --worktrees` for Git repositories when future rifts should be registered as real Git worktrees without rewriting the root repository. Rift snapshots the root `.git` directory into Rift-managed storage, leaves the root workspace unchanged, and makes future rifts share refs, objects, and config through that forked Git snapshot. The shared Git storage is named `rift-manager` under Rift's repo storage. Commits and branches created in the root after initialization are not mirrored back into the rift snapshot, but creating a new rift from the root imports the root's current `HEAD` commit so the new rift starts from the latest tree state.
 
 ### Create
 
@@ -61,7 +61,7 @@ On btrfs, it creates a writable subvolume snapshot. On XFS, it reflink-clones th
 
 When the workspace is a Git repository, the new workspace has detached `HEAD` and retains index and working-tree state.
 
-When the root was initialized with `rift init --worktrees`, created rifts are also registered as Git worktrees and appear in `git worktree list`.
+When the root was initialized with `rift init --worktrees`, created rifts are registered as Git worktrees in Rift's forked Git snapshot and appear in `git --git-dir <shared snapshot> worktree list`.
 
 ### List And Ancestors
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ rift init --worktrees
 
 On Linux, first initialization of an ordinary btrfs directory performs a reflink import into a new btrfs subvolume and swaps it into the same path. On XFS, initialization verifies that the filesystem supports reflinks and registers the directory in place. If the selected root is registered already, no conversion occurs. If its `.rift` marker is missing, `rift init` restores it and completes any required setup.
 
-Use `rift init --worktrees` for Git repositories when future rifts should be registered as real Git worktrees. This moves the repository's `.git` directory into Rift's data directory, leaves a `.git` pointer file in the workspace, and makes future rifts share Git refs, objects, and config through that external Git directory. Do not delete the Rift data directory for a worktree-initialized repo while its workspaces still exist.
+Use `rift init --worktrees` for Git repositories when future rifts should be registered as real Git worktrees. This moves the repository's `.git` directory into Rift's data directory, leaves a `.git` pointer file in the workspace, and makes future rifts share Git refs, objects, and config through that external Git directory. The shared Git storage is named `rift-manager` under Rift's repo storage. Do not delete the Rift data directory for a worktree-initialized repo while its workspaces still exist.
 
 ### Create
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ Release archives are available from [GitHub Releases](https://github.com/anomaly
 ```bash
 cd ~/code/app
 rift init
+rift init --worktrees
 ```
 
 `rift init` selects an existing Rift root above the current directory, or the nearest Git root when no Rift root exists. Use `--here` to initialize exactly the selected directory.
 
 On Linux, first initialization of an ordinary btrfs directory performs a reflink import into a new btrfs subvolume and swaps it into the same path. On XFS, initialization verifies that the filesystem supports reflinks and registers the directory in place. If the selected root is registered already, no conversion occurs. If its `.rift` marker is missing, `rift init` restores it and completes any required setup.
+
+Use `rift init --worktrees` for Git repositories when future rifts should be registered as real Git worktrees. This moves the repository's `.git` directory into Rift's data directory, leaves a `.git` pointer file in the workspace, and makes future rifts share Git refs, objects, and config through that external Git directory. Do not delete the Rift data directory for a worktree-initialized repo while its workspaces still exist.
 
 ### Create
 
@@ -57,6 +60,8 @@ rift create --into /fast/rifts
 On btrfs, it creates a writable subvolume snapshot. On XFS, it reflink-clones the directory tree. On macOS, it uses APFS `clonefile`.
 
 When the workspace is a Git repository, the new workspace has detached `HEAD` and retains index and working-tree state.
+
+When the root was initialized with `rift init --worktrees`, created rifts are also registered as Git worktrees and appear in `git worktree list`.
 
 ### List And Ancestors
 
@@ -130,7 +135,7 @@ With Node's permission model, also pass `--allow-ffi`.
 ### Functions
 
 ```ts
-init(options?: { at?: string; database?: string }): null
+init(options?: { at?: string; worktrees?: boolean; database?: string }): null
 create(options?: { from?: string; name?: string; into?: string; database?: string }): string
 remove(options?: { at?: string; all?: false; database?: string }): void
 remove(options: { at?: string; all: true; database?: string }): string[]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
-use rift::{Create, InitProgress, Manager};
+use rift::{Create, Init, InitProgress, Manager};
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -89,6 +89,11 @@ enum Command {
         at: Option<PathBuf>,
         #[arg(long)]
         here: bool,
+        #[arg(
+            long,
+            help = "Move .git into Rift data storage and register future rifts as Git worktrees"
+        )]
+        worktrees: bool,
     },
     Create {
         from: Option<PathBuf>,
@@ -157,26 +162,36 @@ fn run() -> Result<()> {
             print_shell_init(shell);
             Ok(())
         }
-        Command::Init { at, here } => {
+        Command::Init {
+            at,
+            here,
+            worktrees,
+        } => {
             let requested = std::fs::canonicalize(at.unwrap_or(std::env::current_dir()?))?;
             let (at, existing, missing_marker) = init_target(&manager, &requested, here)?;
             let initialized_from_inside = std::env::current_dir()?.starts_with(&at);
             let mut converting = false;
-            let outcome = manager.init_with_progress(&at, |progress| match progress {
-                InitProgress::CreatingSubvolume => {
-                    converting = true;
-                    eprintln!("Initializing  {}\n", at.display());
-                    eprintln!("First-time setup can take a moment.");
-                    eprintln!("New rifts will be instant.\n");
-                    eprintln!("Creating BTRFS subvolume...");
-                }
-                InitProgress::ImportingWorkspace => eprintln!("Importing workspace..."),
-                InitProgress::ImportedEntries { .. } => {}
-                InitProgress::ActivatingWorkspace
-                | InitProgress::RegisteringWorkspace
-                | InitProgress::RestoringMarker
-                | InitProgress::RemovingOriginal => {}
-            })?;
+            let outcome = manager.init_options_with_progress(
+                Init {
+                    at: at.clone(),
+                    worktrees,
+                },
+                |progress| match progress {
+                    InitProgress::CreatingSubvolume => {
+                        converting = true;
+                        eprintln!("Initializing  {}\n", at.display());
+                        eprintln!("First-time setup can take a moment.");
+                        eprintln!("New rifts will be instant.\n");
+                        eprintln!("Creating BTRFS subvolume...");
+                    }
+                    InitProgress::ImportingWorkspace => eprintln!("Importing workspace..."),
+                    InitProgress::ImportedEntries { .. } => {}
+                    InitProgress::ActivatingWorkspace
+                    | InitProgress::RegisteringWorkspace
+                    | InitProgress::RestoringMarker
+                    | InitProgress::RemovingOriginal => {}
+                },
+            )?;
             if outcome.is_converted() {
                 if converting {
                     eprintln!("\nReady  {}", at.display());

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -1,12 +1,19 @@
 use crate::{Error, Result};
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Source {
     PlainDirectory,
     Repository,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GitDirs {
+    pub(crate) git_dir: PathBuf,
+    pub(crate) common_dir: PathBuf,
 }
 
 impl Source {
@@ -26,6 +33,35 @@ pub(crate) fn check_source(path: &Path) -> Result<Source> {
         ));
     }
 
+    check_safe_state(path)?;
+    Ok(Source::Repository)
+}
+
+pub(crate) fn check_source_allow_worktree(path: &Path) -> Result<Source> {
+    if !path.join(".git").exists() {
+        return Ok(Source::PlainDirectory);
+    }
+    resolve_dirs(path)?.ok_or_else(|| Error::UnsafeGit("invalid Git repository".into()))?;
+    check_safe_state(path)?;
+    Ok(Source::Repository)
+}
+
+pub(crate) fn resolve_dirs(path: &Path) -> Result<Option<GitDirs>> {
+    if !path.join(".git").exists() {
+        return Ok(None);
+    }
+    let git_dir = git_path(path, "--git-dir")?;
+    let common_dir = git_path(path, "--git-common-dir")?;
+    Ok(Some(GitDirs {
+        git_dir,
+        common_dir,
+    }))
+}
+
+fn check_safe_state(path: &Path) -> Result<()> {
+    let Some(dirs) = resolve_dirs(path)? else {
+        return Ok(());
+    };
     for state in [
         "MERGE_HEAD",
         "CHERRY_PICK_HEAD",
@@ -36,15 +72,18 @@ pub(crate) fn check_source(path: &Path) -> Result<Source> {
         "index.lock",
         "HEAD.lock",
     ] {
-        if git.join(state).exists() {
+        if dirs.git_dir.join(state).exists() {
             return Err(Error::UnsafeGit(format!("Git state in progress: {state}")));
         }
     }
-    Ok(Source::Repository)
+    Ok(())
 }
 
 pub(crate) fn hide_marker(path: &Path) -> Result<()> {
-    let info = path.join(".git").join("info");
+    let Some(dirs) = resolve_dirs(path)? else {
+        return Ok(());
+    };
+    let info = dirs.common_dir.join("info");
     fs::create_dir_all(&info)?;
     let exclude = info.join("exclude");
     let existing = match fs::read_to_string(&exclude) {
@@ -69,7 +108,9 @@ pub(crate) fn detach_destination(path: &Path) -> Result<()> {
     // Avoid process startup when libgit2 understands the repository;
     // the Git CLI remains the authority for layouts it cannot resolve.
     if let Some(commit) = resolve_head_commit(path) {
-        fs::write(path.join(".git").join("HEAD"), format!("{commit}\n"))?;
+        if let Some(dirs) = resolve_dirs(path)? {
+            fs::write(dirs.git_dir.join("HEAD"), format!("{commit}\n"))?;
+        }
         return Ok(());
     }
 
@@ -82,8 +123,31 @@ pub(crate) fn detach_destination(path: &Path) -> Result<()> {
         return Ok(());
     }
     let commit = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    fs::write(path.join(".git").join("HEAD"), format!("{commit}\n"))?;
+    if let Some(dirs) = resolve_dirs(path)? {
+        fs::write(dirs.git_dir.join("HEAD"), format!("{commit}\n"))?;
+    }
     Ok(())
+}
+
+fn git_path(path: &Path, flag: &str) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--path-format=absolute", flag])
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::UnsafeGit(format!(
+            "failed to resolve Git path with {flag}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if value.is_empty() {
+        return Err(Error::UnsafeGit(format!(
+            "Git returned an empty path for {flag}"
+        )));
+    }
+    Ok(PathBuf::from(value))
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -119,19 +183,18 @@ mod tests {
         assert_eq!(check_source(plain.path()).unwrap(), Source::PlainDirectory);
 
         let git = TempDir::new().unwrap();
-        fs::create_dir(git.path().join(".git")).unwrap();
+        run(git.path(), &["init"]);
         assert_eq!(check_source(git.path()).unwrap(), Source::Repository);
     }
 
     #[test]
     fn hide_marker_creates_and_appends_exclude_cleanly() {
         let temp = TempDir::new().unwrap();
-        fs::create_dir(temp.path().join(".git")).unwrap();
+        run(temp.path(), &["init"]);
 
         hide_marker(temp.path()).unwrap();
-        assert_eq!(
-            fs::read_to_string(temp.path().join(".git/info/exclude")).unwrap(),
-            "/.rift\n"
+        assert_marker_is_excluded(
+            &fs::read_to_string(temp.path().join(".git/info/exclude")).unwrap(),
         );
         fs::write(temp.path().join(".git/info/exclude"), "existing").unwrap();
         hide_marker(temp.path()).unwrap();
@@ -144,6 +207,29 @@ mod tests {
             fs::read_to_string(temp.path().join(".git/info/exclude")).unwrap(),
             "existing\n/.rift\n"
         );
+    }
+
+    #[test]
+    fn hide_marker_uses_common_dir_for_linked_worktrees() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        let linked = temp.path().join("linked");
+        fs::create_dir(&repo).unwrap();
+        run(&repo, &["init"]);
+        run(&repo, &["config", "user.email", "test@example.com"]);
+        run(&repo, &["config", "user.name", "Test"]);
+        fs::write(repo.join("file.txt"), "hello").unwrap();
+        run(&repo, &["add", "file.txt"]);
+        run(&repo, &["commit", "-m", "initial"]);
+        run(
+            &repo,
+            &["worktree", "add", "--detach", linked.to_str().unwrap()],
+        );
+
+        hide_marker(&linked).unwrap();
+
+        let common = resolve_dirs(&linked).unwrap().unwrap().common_dir;
+        assert_marker_is_excluded(&fs::read_to_string(common.join("info/exclude")).unwrap());
     }
 
     #[test]
@@ -165,6 +251,28 @@ mod tests {
         assert_eq!(
             fs::read_to_string(temp.path().join(".git/HEAD")).unwrap(),
             head
+        );
+    }
+
+    fn run(path: &Path, args: &[&str]) {
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(path)
+                .args(args)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+
+    fn assert_marker_is_excluded(contents: &str) {
+        assert_eq!(
+            contents
+                .lines()
+                .filter(|line| line.trim() == "/.rift")
+                .count(),
+            1
         );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,10 +4,12 @@ mod marker;
 mod name;
 mod registry;
 mod strategy;
+mod worktree;
 
 use id::RiftId;
 use name::RiftName;
 use registry::{MovedRecord, PathRecord, Record, Registry, SubtreeScope};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use strategy::{Strategy, StrategyInit};
@@ -57,6 +59,33 @@ pub struct Create {
     pub into: Option<PathBuf>,
 }
 
+pub struct Init {
+    pub at: PathBuf,
+    pub worktrees: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitStorageMode {
+    Inline,
+    SharedWorktrees,
+}
+
+impl GitStorageMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Inline => "inline",
+            Self::SharedWorktrees => "shared_worktrees",
+        }
+    }
+
+    pub(crate) fn from_stored(value: String) -> Self {
+        match value.as_str() {
+            "shared_worktrees" => Self::SharedWorktrees,
+            _ => Self::Inline,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum InitProgress {
     CreatingSubvolume,
@@ -84,6 +113,7 @@ impl InitOutcome {
 pub struct Manager {
     registry: Registry,
     strategy: Box<dyn Strategy>,
+    repo_storage: PathBuf,
 }
 
 impl Manager {
@@ -101,15 +131,36 @@ impl Manager {
 
     fn with_strategy(path: impl AsRef<Path>, strategy: Box<dyn Strategy>) -> Result<Self> {
         let registry = Registry::open(path)?;
-        Ok(Self { registry, strategy })
+        Ok(Self {
+            registry,
+            strategy,
+            repo_storage: default_repo_storage()?,
+        })
+    }
+
+    #[cfg(test)]
+    fn with_strategy_and_repo_storage(
+        path: impl AsRef<Path>,
+        strategy: Box<dyn Strategy>,
+        repo_storage: PathBuf,
+    ) -> Result<Self> {
+        let registry = Registry::open(path)?;
+        Ok(Self {
+            registry,
+            strategy,
+            repo_storage,
+        })
     }
 
     pub fn create(&mut self, input: Create) -> Result<PathBuf> {
         let requested = existing_directory(&input.from)?;
         let source = self.workspace_from(&requested)?;
         let from = source.path.clone();
-        let git = git::check_source(&from)?;
         let root = self.root(&source)?;
+        let git = match root.git_storage_mode {
+            GitStorageMode::Inline => git::check_source(&from)?,
+            GitStorageMode::SharedWorktrees => git::check_source_allow_worktree(&from)?,
+        };
         let id = RiftId::new();
         let destination_parent = match input.into {
             Some(path) => absolute_path(&path)?,
@@ -136,19 +187,52 @@ impl Manager {
             return Err(error);
         }
 
+        let mut git_worktree_dir = None;
         let result = (|| {
-            marker::write(&destination, &id)?;
-            if git.is_repository() {
-                git::hide_marker(&destination)?;
-                git::detach_destination(&destination)?;
+            match root.git_storage_mode {
+                GitStorageMode::Inline => {
+                    marker::write(&destination, &id)?;
+                    if git.is_repository() {
+                        git::hide_marker(&destination)?;
+                        git::detach_destination(&destination)?;
+                    }
+                    if git.is_repository() {
+                        git::hide_marker(&from)?;
+                    }
+                }
+                GitStorageMode::SharedWorktrees => {
+                    let shared_git_dir = root.shared_git_dir.as_ref().ok_or_else(|| {
+                        Error::UnsafeGit("shared Git directory is missing from registry".into())
+                    })?;
+                    if git.is_repository() {
+                        let registered =
+                            worktree::register_cow_clone(shared_git_dir, &from, &destination, &id)?;
+                        git_worktree_dir = Some(registered.git_dir);
+                        git::hide_marker(&destination)?;
+                        git::hide_marker(&from)?;
+                    }
+                    marker::write(&destination, &id)?;
+                }
             }
-            if git.is_repository() {
-                git::hide_marker(&from)?;
-            }
-            self.registry.insert_child(&id, &source.id, &destination)?;
+            self.registry.insert_child(
+                &id,
+                &source.id,
+                &destination,
+                root.git_storage_mode,
+                root.shared_git_dir.as_deref(),
+                git_worktree_dir.as_deref(),
+            )?;
             Ok(destination.clone())
         })();
         if result.is_err() {
+            if let (Some(shared_git_dir), Some(git_worktree_dir)) =
+                (root.shared_git_dir.as_ref(), git_worktree_dir.as_ref())
+            {
+                if worktree::validate_worktree_dir(shared_git_dir, git_worktree_dir).is_ok() {
+                    let _ = worktree::remove_registered_worktree(git_worktree_dir);
+                    let _ = worktree::prune(shared_git_dir);
+                }
+            }
             let _ = self.strategy.remove_directory(&destination);
         }
         result
@@ -158,14 +242,40 @@ impl Manager {
         self.init_with_progress(at, |_| {})
     }
 
+    pub fn init_options(&mut self, input: Init) -> Result<InitOutcome> {
+        self.init_options_with_progress(input, |_| {})
+    }
+
     pub fn init_with_progress(
         &mut self,
         at: impl AsRef<Path>,
+        progress: impl FnMut(InitProgress),
+    ) -> Result<InitOutcome> {
+        self.init_options_with_progress(
+            Init {
+                at: at.as_ref().to_path_buf(),
+                worktrees: false,
+            },
+            progress,
+        )
+    }
+
+    pub fn init_options_with_progress(
+        &mut self,
+        input: Init,
         mut progress: impl FnMut(InitProgress),
     ) -> Result<InitOutcome> {
-        let at = existing_directory(at.as_ref())?;
-        let git = git::check_source(&at)?;
+        let at = existing_directory(&input.at)?;
         if let Some(record) = self.registry.record_at(&at)? {
+            if input.worktrees && record.git_storage_mode != GitStorageMode::SharedWorktrees {
+                return Err(Error::UnsafeGit(
+                    "workspace is already initialized without --worktrees".into(),
+                ));
+            }
+            let git = match record.git_storage_mode {
+                GitStorageMode::Inline => git::check_source(&at)?,
+                GitStorageMode::SharedWorktrees => git::check_source_allow_worktree(&at)?,
+            };
             if marker::read(&at)?.is_none() {
                 progress(InitProgress::RestoringMarker);
                 marker::write(&at, &record.id)?;
@@ -181,19 +291,43 @@ impl Manager {
                 StrategyInit::Converted => InitOutcome::Converted,
             });
         }
+        let git = if input.worktrees {
+            git::check_source_allow_worktree(&at)?
+        } else {
+            git::check_source(&at)?
+        };
         if marker::read(&at)?.is_some() {
             return Err(Error::MarkerMismatch(at));
+        }
+        if input.worktrees && !git.is_repository() {
+            return Err(Error::UnsafeGit(
+                "rift init --worktrees requires a Git repository".into(),
+            ));
+        }
+        if input.worktrees {
+            worktree::ensure_head_commit(&at)?;
         }
 
         let converted = self.strategy.initialize_directory(&at, &mut progress)?;
         progress(InitProgress::RegisteringWorkspace);
         let id = RiftId::new();
+        let shared_git = if input.worktrees {
+            Some(worktree::initialize_root(&at, &id, &self.repo_storage)?.git_dir)
+        } else {
+            None
+        };
+        let git_storage_mode = if input.worktrees {
+            GitStorageMode::SharedWorktrees
+        } else {
+            GitStorageMode::Inline
+        };
         let result = (|| {
             marker::write(&at, &id)?;
             if git.is_repository() {
                 git::hide_marker(&at)?;
             }
-            self.registry.insert_root(&id, &at)?;
+            self.registry
+                .insert_root(&id, &at, git_storage_mode, shared_git.as_deref())?;
             Ok(match converted {
                 StrategyInit::AlreadyNative => InitOutcome::Registered,
                 StrategyInit::Converted => InitOutcome::Converted,
@@ -201,6 +335,9 @@ impl Manager {
         })();
         if result.is_err() {
             let _ = fs::remove_file(marker::path(&at));
+            if let Some(shared_git) = &shared_git {
+                worktree::restore_inline_root(&at, shared_git)?;
+            }
         }
         result
     }
@@ -234,10 +371,27 @@ impl Manager {
             .registry
             .subtree(&record.id, SubtreeScope::DescendantsOnly)?;
         let existing = rows
-            .into_iter()
+            .iter()
             .filter(|record| record.path.exists())
+            .cloned()
             .collect::<Vec<_>>();
+        let missing = rows
+            .iter()
+            .filter(|record| !record.path.exists())
+            .cloned()
+            .collect::<Vec<_>>();
+        if record.git_storage_mode == GitStorageMode::SharedWorktrees {
+            if let Some(shared_git_dir) = &record.shared_git_dir {
+                worktree::validate_inline_root_restore(&record.path, shared_git_dir)?;
+            }
+        }
         self.trash_rows(&existing)?;
+        cleanup_worktrees(&missing)?;
+        if record.git_storage_mode == GitStorageMode::SharedWorktrees {
+            if let Some(shared_git_dir) = &record.shared_git_dir {
+                worktree::restore_inline_root(&record.path, shared_git_dir)?;
+            }
+        }
         fs::remove_file(marker::path(&record.path))?;
         self.registry.delete_active(&record.id)?;
         Ok(())
@@ -289,8 +443,9 @@ impl Manager {
             for record in moved.iter().rev() {
                 let _ = fs::rename(&record.trash_path, &record.original_path);
             }
+            return result;
         }
-        result
+        cleanup_worktrees(rows)
     }
 
     pub fn list(&self, of: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
@@ -314,9 +469,9 @@ impl Manager {
     }
 
     pub fn gc(&mut self) -> Result<Vec<PathBuf>> {
-        let removed = self
-            .registry
-            .trashed_paths()?
+        let trashed = self.registry.trashed_paths()?;
+        cleanup_worktrees(&trashed)?;
+        let removed = trashed
             .into_iter()
             .map(|row| -> Result<PathBuf> {
                 if row.path.exists() {
@@ -344,6 +499,7 @@ impl Manager {
             })
             .filter_map(Result::transpose)
             .collect::<Result<Vec<_>>>()?;
+        cleanup_worktrees(&missing)?;
         self.registry.delete_active_records(&missing)?;
         Ok(removed
             .into_iter()
@@ -402,6 +558,12 @@ fn default_database_path() -> Result<PathBuf> {
     Ok(base.join("rift").join("rift.sqlite"))
 }
 
+fn default_repo_storage() -> Result<PathBuf> {
+    let base = dirs::data_local_dir()
+        .ok_or_else(|| Error::Path("user data directory is unavailable".into()))?;
+    Ok(base.join("rift").join("repos"))
+}
+
 fn existing_directory(path: &Path) -> Result<PathBuf> {
     let path = fs::canonicalize(path)?;
     if !path.is_dir() {
@@ -439,6 +601,26 @@ fn trash_path(id: &RiftId, path: &Path) -> Result<PathBuf> {
         .join(format!("{id}-{}", name.to_string_lossy())))
 }
 
+fn cleanup_worktrees(rows: &[PathRecord]) -> Result<()> {
+    let mut pruned = HashSet::<PathBuf>::new();
+    for row in rows {
+        let Some(shared_git_dir) = &row.shared_git_dir else {
+            continue;
+        };
+
+        if let Some(git_dir) = &row.git_worktree_dir {
+            worktree::validate_worktree_dir(shared_git_dir, git_dir)?;
+            worktree::remove_registered_worktree(git_dir)?;
+            if pruned.insert(shared_git_dir.clone()) && shared_git_dir.exists() {
+                worktree::prune(shared_git_dir)?;
+            }
+        } else {
+            worktree::remove_shared_git_storage(shared_git_dir, &row.id)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -450,7 +632,12 @@ mod tests {
     use ulid::Ulid;
 
     fn manager(temp: &TempDir) -> Manager {
-        Manager::with_strategy(temp.path().join("registry.sqlite"), Box::new(TestStrategy)).unwrap()
+        Manager::with_strategy_and_repo_storage(
+            temp.path().join("registry.sqlite"),
+            Box::new(TestStrategy),
+            temp.path().join("repos"),
+        )
+        .unwrap()
     }
 
     fn source(temp: &TempDir) -> PathBuf {
@@ -1220,6 +1407,246 @@ mod tests {
     }
 
     #[test]
+    fn init_worktrees_externalizes_git_directory() {
+        let temp = TempDir::new().unwrap();
+        let source = source(&temp);
+        initialize_git_repo(&source);
+        let mut manager = manager(&temp);
+
+        manager
+            .init_options(Init {
+                at: source.clone(),
+                worktrees: true,
+            })
+            .unwrap();
+
+        assert!(source.join(".git").is_file());
+        let record = manager.registry.record_at(&source).unwrap().unwrap();
+        assert_eq!(record.git_storage_mode, GitStorageMode::SharedWorktrees);
+        let shared_git_dir = record.shared_git_dir.unwrap();
+        assert!(shared_git_dir.is_dir());
+        assert!(shared_git_dir.starts_with(temp.path().join("repos")));
+        assert_eq!(
+            fs::read_to_string(source.join(".git")).unwrap(),
+            format!("gitdir: {}\n", shared_git_dir.display())
+        );
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&source)
+            .args(["status", "--porcelain"])
+            .output()
+            .unwrap();
+        assert!(status.status.success());
+
+        let _ = fs::remove_dir_all(shared_git_dir.parent().unwrap());
+    }
+
+    #[test]
+    fn init_worktrees_is_idempotent_without_flag() {
+        let temp = TempDir::new().unwrap();
+        let source = source(&temp);
+        initialize_git_repo(&source);
+        let mut manager = manager(&temp);
+        manager
+            .init_options(Init {
+                at: source.clone(),
+                worktrees: true,
+            })
+            .unwrap();
+
+        assert_eq!(
+            manager.init(&source).unwrap(),
+            InitOutcome::AlreadyInitialized
+        );
+    }
+
+    #[test]
+    fn init_worktrees_rejects_unborn_repository_before_externalizing_git() {
+        let temp = TempDir::new().unwrap();
+        let source = source(&temp);
+        run(&source, &["init"]);
+        let mut manager = manager(&temp);
+
+        let error = manager
+            .init_options(Init {
+                at: source.clone(),
+                worktrees: true,
+            })
+            .unwrap_err();
+
+        assert!(matches!(error, Error::UnsafeGit(_)));
+        assert!(source.join(".git").is_dir());
+        assert!(manager.registry.record_at(&source).unwrap().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn init_worktrees_rejects_git_symlink() {
+        let temp = TempDir::new().unwrap();
+        let source = source(&temp);
+        initialize_git_repo(&source);
+        fs::rename(source.join(".git"), source.join("actual.git")).unwrap();
+        std::os::unix::fs::symlink(source.join("actual.git"), source.join(".git")).unwrap();
+        let mut manager = manager(&temp);
+
+        let error = manager
+            .init_options(Init {
+                at: source.clone(),
+                worktrees: true,
+            })
+            .unwrap_err();
+
+        assert!(matches!(error, Error::UnsafeGit(_)));
+        assert!(source.join(".git").is_symlink());
+        assert!(source.join("actual.git").is_dir());
+    }
+
+    #[test]
+    fn create_from_worktree_root_registers_child_as_git_worktree() {
+        let temp = TempDir::new().unwrap();
+        let source = source(&temp);
+        initialize_git_repo(&source);
+        fs::write(source.join("file.txt"), "changed").unwrap();
+        run(&source, &["add", "file.txt"]);
+        fs::write(source.join("untracked.txt"), "new").unwrap();
+        let mut manager = manager(&temp);
+        manager
+            .init_options(Init {
+                at: source.clone(),
+                worktrees: true,
+            })
+            .unwrap();
+
+        let destination = manager
+            .create(Create {
+                from: source.clone(),
+                name: Some("worktree".into()),
+                into: None,
+            })
+            .unwrap();
+
+        assert!(destination.join(".git").is_file());
+        assert!(destination.join("untracked.txt").exists());
+        let staged = Command::new("git")
+            .arg("-C")
+            .arg(&destination)
+            .args(["diff", "--cached", "--name-only"])
+            .output()
+            .unwrap();
+        assert!(String::from_utf8_lossy(&staged.stdout).contains("file.txt"));
+        assert!(
+            !Command::new("git")
+                .arg("-C")
+                .arg(&destination)
+                .args(["symbolic-ref", "-q", "HEAD"])
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        run(&source, &["branch", "shared-ref"]);
+        let branches = Command::new("git")
+            .arg("-C")
+            .arg(&destination)
+            .args(["branch", "--list", "shared-ref"])
+            .output()
+            .unwrap();
+        assert!(String::from_utf8_lossy(&branches.stdout).contains("shared-ref"));
+
+        let root = manager
+            .root(&manager.workspace_at(&source).unwrap())
+            .unwrap();
+        let shared_git_dir = root.shared_git_dir.unwrap();
+        let worktrees = Command::new("git")
+            .arg("--git-dir")
+            .arg(&shared_git_dir)
+            .args(["worktree", "list", "--porcelain"])
+            .output()
+            .unwrap();
+        assert!(String::from_utf8_lossy(&worktrees.stdout).contains(destination.to_str().unwrap()));
+
+        manager.remove(&destination).unwrap();
+        let worktrees = Command::new("git")
+            .arg("--git-dir")
+            .arg(&shared_git_dir)
+            .args(["worktree", "list", "--porcelain"])
+            .output()
+            .unwrap();
+        assert!(
+            !String::from_utf8_lossy(&worktrees.stdout).contains(destination.to_str().unwrap())
+        );
+        let _ = fs::remove_dir_all(shared_git_dir.parent().unwrap());
+    }
+
+    #[test]
+    fn remove_worktree_root_restores_inline_git_directory() {
+        let temp = TempDir::new().unwrap();
+        let source = source(&temp);
+        initialize_git_repo(&source);
+        let mut manager = manager(&temp);
+        manager
+            .init_options(Init {
+                at: source.clone(),
+                worktrees: true,
+            })
+            .unwrap();
+        assert!(source.join(".git").is_file());
+        let shared_git_dir = manager
+            .registry
+            .record_at(&source)
+            .unwrap()
+            .unwrap()
+            .shared_git_dir
+            .unwrap();
+
+        manager.remove(&source).unwrap();
+
+        assert!(source.join(".git").is_dir());
+        assert!(!shared_git_dir.parent().unwrap().exists());
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&source)
+            .args(["status", "--porcelain"])
+            .output()
+            .unwrap();
+        assert!(status.status.success());
+        assert!(String::from_utf8_lossy(&status.stdout).is_empty());
+    }
+
+    #[test]
+    fn remove_worktree_root_cleans_missing_child_git_metadata() {
+        let temp = TempDir::new().unwrap();
+        let source = source(&temp);
+        initialize_git_repo(&source);
+        let mut manager = manager(&temp);
+        manager
+            .init_options(Init {
+                at: source.clone(),
+                worktrees: true,
+            })
+            .unwrap();
+        let child = manager
+            .create(Create {
+                from: source.clone(),
+                name: Some("missing".into()),
+                into: None,
+            })
+            .unwrap();
+        let child_id = marker_id(&child);
+        fs::remove_dir_all(&child).unwrap();
+
+        manager.remove(&source).unwrap();
+
+        assert!(source.join(".git").is_dir());
+        assert!(
+            !source
+                .join(".git/worktrees")
+                .join(child_id.as_str())
+                .exists()
+        );
+    }
+
+    #[test]
     fn create_requires_an_initialized_workspace() {
         let temp = TempDir::new().unwrap();
         let source = source(&temp);
@@ -1288,5 +1715,13 @@ mod tests {
                 .unwrap()
                 .success()
         );
+    }
+
+    fn initialize_git_repo(path: &Path) {
+        run(path, &["init"]);
+        run(path, &["config", "user.email", "test@example.com"]);
+        run(path, &["config", "user.name", "Test"]);
+        run(path, &["add", "file.txt"]);
+        run(path, &["commit", "-m", "initial"]);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -312,7 +312,12 @@ impl Manager {
         progress(InitProgress::RegisteringWorkspace);
         let id = RiftId::new();
         let shared_git = if input.worktrees {
-            Some(worktree::initialize_root(&at, &id, &self.repo_storage)?.git_dir)
+            Some(
+                worktree::initialize_root(&at, &id, &self.repo_storage, |from, to| {
+                    self.strategy.copy_directory(from, to)
+                })?
+                .git_dir,
+            )
         } else {
             None
         };
@@ -336,7 +341,7 @@ impl Manager {
         if result.is_err() {
             let _ = fs::remove_file(marker::path(&at));
             if let Some(shared_git) = &shared_git {
-                worktree::restore_inline_root(&at, shared_git)?;
+                let _ = worktree::remove_shared_git_storage(shared_git, &id);
             }
         }
         result
@@ -380,17 +385,10 @@ impl Manager {
             .filter(|record| !record.path.exists())
             .cloned()
             .collect::<Vec<_>>();
-        if record.git_storage_mode == GitStorageMode::SharedWorktrees {
-            if let Some(shared_git_dir) = &record.shared_git_dir {
-                worktree::validate_inline_root_restore(&record.path, shared_git_dir)?;
-            }
-        }
         self.trash_rows(&existing)?;
         cleanup_worktrees(&missing)?;
-        if record.git_storage_mode == GitStorageMode::SharedWorktrees {
-            if let Some(shared_git_dir) = &record.shared_git_dir {
-                worktree::restore_inline_root(&record.path, shared_git_dir)?;
-            }
+        if let Some(shared_git_dir) = &record.shared_git_dir {
+            worktree::remove_shared_git_storage(shared_git_dir, &record.id)?;
         }
         fs::remove_file(marker::path(&record.path))?;
         self.registry.delete_active(&record.id)?;
@@ -1407,7 +1405,7 @@ mod tests {
     }
 
     #[test]
-    fn init_worktrees_externalizes_git_directory() {
+    fn init_worktrees_snapshots_git_directory_without_mutating_root() {
         let temp = TempDir::new().unwrap();
         let source = source(&temp);
         initialize_git_repo(&source);
@@ -1420,17 +1418,14 @@ mod tests {
             })
             .unwrap();
 
-        assert!(source.join(".git").is_file());
+        assert!(source.join(".git").is_dir());
         let record = manager.registry.record_at(&source).unwrap().unwrap();
         assert_eq!(record.git_storage_mode, GitStorageMode::SharedWorktrees);
         let shared_git_dir = record.shared_git_dir.unwrap();
         assert!(shared_git_dir.is_dir());
         assert!(shared_git_dir.starts_with(temp.path().join("repos")));
         assert_eq!(shared_git_dir.file_name().unwrap(), "rift-manager");
-        assert_eq!(
-            fs::read_to_string(source.join(".git")).unwrap(),
-            format!("gitdir: {}\n", shared_git_dir.display())
-        );
+        assert!(source.join(".git/HEAD").exists());
         let status = Command::new("git")
             .arg("-C")
             .arg(&source)
@@ -1462,7 +1457,7 @@ mod tests {
     }
 
     #[test]
-    fn init_worktrees_rejects_unborn_repository_before_externalizing_git() {
+    fn init_worktrees_rejects_unborn_repository_before_snapshotting_git() {
         let temp = TempDir::new().unwrap();
         let source = source(&temp);
         run(&source, &["init"]);
@@ -1545,15 +1540,6 @@ mod tests {
                 .success()
         );
 
-        run(&source, &["branch", "shared-ref"]);
-        let branches = Command::new("git")
-            .arg("-C")
-            .arg(&destination)
-            .args(["branch", "--list", "shared-ref"])
-            .output()
-            .unwrap();
-        assert!(String::from_utf8_lossy(&branches.stdout).contains("shared-ref"));
-
         let root = manager
             .root(&manager.workspace_at(&source).unwrap())
             .unwrap();
@@ -1581,7 +1567,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_worktree_root_restores_inline_git_directory() {
+    fn create_from_worktree_root_imports_new_root_commits_into_snapshot() {
         let temp = TempDir::new().unwrap();
         let source = source(&temp);
         initialize_git_repo(&source);
@@ -1592,7 +1578,57 @@ mod tests {
                 worktrees: true,
             })
             .unwrap();
-        assert!(source.join(".git").is_file());
+
+        fs::write(source.join("later.txt"), "later").unwrap();
+        run(&source, &["add", "later.txt"]);
+        run(&source, &["commit", "-m", "later"]);
+        let expected = Command::new("git")
+            .arg("-C")
+            .arg(&source)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+
+        let destination = manager
+            .create(Create {
+                from: source.clone(),
+                name: Some("later-worktree".into()),
+                into: None,
+            })
+            .unwrap();
+
+        let head = Command::new("git")
+            .arg("-C")
+            .arg(&destination)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&head.stdout),
+            String::from_utf8_lossy(&expected.stdout)
+        );
+        let branch = Command::new("git")
+            .arg("-C")
+            .arg(&destination)
+            .args(["branch", "--show-current"])
+            .output()
+            .unwrap();
+        assert!(String::from_utf8_lossy(&branch.stdout).trim().is_empty());
+    }
+
+    #[test]
+    fn remove_worktree_root_preserves_inline_git_directory() {
+        let temp = TempDir::new().unwrap();
+        let source = source(&temp);
+        initialize_git_repo(&source);
+        let mut manager = manager(&temp);
+        manager
+            .init_options(Init {
+                at: source.clone(),
+                worktrees: true,
+            })
+            .unwrap();
+        assert!(source.join(".git").is_dir());
         let shared_git_dir = manager
             .registry
             .record_at(&source)

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1426,6 +1426,7 @@ mod tests {
         let shared_git_dir = record.shared_git_dir.unwrap();
         assert!(shared_git_dir.is_dir());
         assert!(shared_git_dir.starts_with(temp.path().join("repos")));
+        assert_eq!(shared_git_dir.file_name().unwrap(), "rift-manager");
         assert_eq!(
             fs::read_to_string(source.join(".git")).unwrap(),
             format!("gitdir: {}\n", shared_git_dir.display())
@@ -1557,6 +1558,7 @@ mod tests {
             .root(&manager.workspace_at(&source).unwrap())
             .unwrap();
         let shared_git_dir = root.shared_git_dir.unwrap();
+        assert_eq!(shared_git_dir.file_name().unwrap(), "rift-manager");
         let worktrees = Command::new("git")
             .arg("--git-dir")
             .arg(&shared_git_dir)
@@ -1598,6 +1600,7 @@ mod tests {
             .unwrap()
             .shared_git_dir
             .unwrap();
+        assert_eq!(shared_git_dir.file_name().unwrap(), "rift-manager");
 
         manager.remove(&source).unwrap();
 

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -474,7 +474,7 @@ mod tests {
         let root = temp.path().join("root");
         let child = temp.path().join("child");
         let trash = temp.path().join(".trash/child");
-        let root_git = temp.path().join("rift/repos/root/git");
+        let root_git = temp.path().join("rift/repos/root/rift-manager");
         let child_git = root_git.join("worktrees/child");
         let root_id = id("root");
         let child_id = id("child");
@@ -521,7 +521,7 @@ mod tests {
         let (temp, registry) = registry();
         let root = temp.path().join("root");
         let child = temp.path().join("child");
-        let root_git = temp.path().join("rift/repos/root/git");
+        let root_git = temp.path().join("rift/repos/root/rift-manager");
         let child_git = root_git.join("worktrees/child");
         let root_id = id("root");
         let child_id = id("child");

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result, id::RiftId};
+use crate::{Error, GitStorageMode, Result, id::RiftId};
 use rusqlite::{Connection, OptionalExtension, Row, params};
 use std::path::{Path, PathBuf};
 
@@ -7,12 +7,16 @@ pub(crate) struct Record {
     pub(crate) id: RiftId,
     pub(crate) parent_id: Option<RiftId>,
     pub(crate) path: PathBuf,
+    pub(crate) git_storage_mode: GitStorageMode,
+    pub(crate) shared_git_dir: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct PathRecord {
     pub(crate) id: RiftId,
     pub(crate) path: PathBuf,
+    pub(crate) shared_git_dir: Option<PathBuf>,
+    pub(crate) git_worktree_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -48,38 +52,67 @@ impl Registry {
             "PRAGMA busy_timeout = 2000;
              PRAGMA journal_mode = WAL;
              PRAGMA foreign_keys = ON;
-             CREATE TABLE IF NOT EXISTS rift (
-               id TEXT PRIMARY KEY,
-               parent_id TEXT REFERENCES rift(id) ON DELETE CASCADE,
-               path TEXT NOT NULL UNIQUE,
-               created_at INTEGER NOT NULL
-              );
+               CREATE TABLE IF NOT EXISTS rift (
+                id TEXT PRIMARY KEY,
+                parent_id TEXT REFERENCES rift(id) ON DELETE CASCADE,
+                path TEXT NOT NULL UNIQUE,
+                created_at INTEGER NOT NULL,
+                git_storage_mode TEXT NOT NULL DEFAULT 'inline',
+                shared_git_dir TEXT,
+                git_worktree_dir TEXT
+               );
               CREATE INDEX IF NOT EXISTS rift_parent_id_idx ON rift(parent_id);
-              CREATE TABLE IF NOT EXISTS trash (
+               CREATE TABLE IF NOT EXISTS trash (
                 id TEXT PRIMARY KEY,
                 path TEXT NOT NULL UNIQUE,
-                removed_at INTEGER NOT NULL
+                removed_at INTEGER NOT NULL,
+                shared_git_dir TEXT,
+                git_worktree_dir TEXT
               );",
         )?;
+        migrate(&database)?;
         Ok(Self { database })
     }
 
-    pub(crate) fn insert_root(&self, id: &RiftId, path: &Path) -> Result<()> {
+    pub(crate) fn insert_root(
+        &self,
+        id: &RiftId,
+        path: &Path,
+        git_storage_mode: GitStorageMode,
+        shared_git_dir: Option<&Path>,
+    ) -> Result<()> {
         self.database.execute(
-            "INSERT INTO rift (id, parent_id, path, created_at) VALUES (?1, NULL, ?2, ?3)",
-            params![id.as_str(), path_text(path)?, timestamp()],
+            "INSERT INTO rift (id, parent_id, path, created_at, git_storage_mode, shared_git_dir, git_worktree_dir) VALUES (?1, NULL, ?2, ?3, ?4, ?5, NULL)",
+            params![
+                id.as_str(),
+                path_text(path)?,
+                timestamp(),
+                git_storage_mode.as_str(),
+                optional_path_text(shared_git_dir)?,
+            ],
         )?;
         Ok(())
     }
 
-    pub(crate) fn insert_child(&self, id: &RiftId, parent_id: &RiftId, path: &Path) -> Result<()> {
+    pub(crate) fn insert_child(
+        &self,
+        id: &RiftId,
+        parent_id: &RiftId,
+        path: &Path,
+        git_storage_mode: GitStorageMode,
+        shared_git_dir: Option<&Path>,
+        git_worktree_dir: Option<&Path>,
+    ) -> Result<()> {
         self.database.execute(
-            "INSERT INTO rift (id, parent_id, path, created_at) VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO rift (id, parent_id, path, created_at, git_storage_mode, shared_git_dir, git_worktree_dir) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             params![
                 id.as_str(),
                 parent_id.as_str(),
                 path_text(path)?,
-                timestamp()
+                timestamp(),
+                git_storage_mode.as_str(),
+                optional_path_text(shared_git_dir)?,
+                optional_path_text(git_worktree_dir)?,
             ],
         )?;
         Ok(())
@@ -88,7 +121,7 @@ impl Registry {
     pub(crate) fn record_at(&self, path: &Path) -> Result<Option<Record>> {
         self.database
             .query_row(
-                "SELECT id, parent_id, path FROM rift WHERE path = ?1",
+                "SELECT id, parent_id, path, git_storage_mode, shared_git_dir, git_worktree_dir FROM rift WHERE path = ?1",
                 [path_text(path)?],
                 record_from_row,
             )
@@ -99,7 +132,7 @@ impl Registry {
     pub(crate) fn record_id(&self, id: &RiftId) -> Result<Option<Record>> {
         self.database
             .query_row(
-                "SELECT id, parent_id, path FROM rift WHERE id = ?1",
+                "SELECT id, parent_id, path, git_storage_mode, shared_git_dir, git_worktree_dir FROM rift WHERE id = ?1",
                 [id.as_str()],
                 record_from_row,
             )
@@ -109,18 +142,20 @@ impl Registry {
 
     pub(crate) fn subtree(&self, id: &RiftId, scope: SubtreeScope) -> Result<Vec<PathRecord>> {
         let mut statement = self.database.prepare(
-            "WITH RECURSIVE subtree(id, path, depth) AS (
-               SELECT id, path, 0 FROM rift WHERE id = ?1
+            "WITH RECURSIVE subtree(id, path, shared_git_dir, git_worktree_dir, depth) AS (
+               SELECT id, path, shared_git_dir, git_worktree_dir, 0 FROM rift WHERE id = ?1
                UNION ALL
-               SELECT rift.id, rift.path, subtree.depth + 1
+               SELECT rift.id, rift.path, rift.shared_git_dir, rift.git_worktree_dir, subtree.depth + 1
                FROM rift JOIN subtree ON rift.parent_id = subtree.id
-             ) SELECT id, path FROM subtree WHERE depth >= ?2 ORDER BY depth DESC, id",
+             ) SELECT id, path, shared_git_dir, git_worktree_dir FROM subtree WHERE depth >= ?2 ORDER BY depth DESC, id",
         )?;
         let rows = statement
             .query_map(params![id.as_str(), scope.min_depth()], |row| {
                 Ok(PathRecord {
                     id: RiftId::from_stored(row.get(0)?),
                     path: PathBuf::from(row.get::<_, String>(1)?),
+                    shared_git_dir: optional_path(row.get(2)?),
+                    git_worktree_dir: optional_path(row.get(3)?),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -148,7 +183,8 @@ impl Registry {
         let transaction = self.database.transaction()?;
         moved.iter().try_for_each(|record| -> Result<()> {
             transaction.execute(
-                "INSERT INTO trash (id, path, removed_at) VALUES (?1, ?2, ?3)",
+                "INSERT INTO trash (id, path, removed_at, shared_git_dir, git_worktree_dir)
+                 SELECT id, ?2, ?3, shared_git_dir, git_worktree_dir FROM rift WHERE id = ?1",
                 params![
                     record.id.as_str(),
                     path_text(&record.trash_path)?,
@@ -163,14 +199,16 @@ impl Registry {
     }
 
     pub(crate) fn trashed_paths(&self) -> Result<Vec<PathRecord>> {
-        let mut statement = self
-            .database
-            .prepare("SELECT id, path FROM trash ORDER BY removed_at, id")?;
+        let mut statement = self.database.prepare(
+            "SELECT id, path, shared_git_dir, git_worktree_dir FROM trash ORDER BY removed_at, id",
+        )?;
         Ok(statement
             .query_map([], |row| {
                 Ok(PathRecord {
                     id: RiftId::from_stored(row.get(0)?),
                     path: PathBuf::from(row.get::<_, String>(1)?),
+                    shared_git_dir: optional_path(row.get(2)?),
+                    git_worktree_dir: optional_path(row.get(3)?),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?)
@@ -183,12 +221,16 @@ impl Registry {
     }
 
     pub(crate) fn active_paths(&self) -> Result<Vec<PathRecord>> {
-        let mut statement = self.database.prepare("SELECT id, path FROM rift")?;
+        let mut statement = self
+            .database
+            .prepare("SELECT id, path, shared_git_dir, git_worktree_dir FROM rift")?;
         Ok(statement
             .query_map([], |row| {
                 Ok(PathRecord {
                     id: RiftId::from_stored(row.get(0)?),
                     path: PathBuf::from(row.get::<_, String>(1)?),
+                    shared_git_dir: optional_path(row.get(2)?),
+                    git_worktree_dir: optional_path(row.get(3)?),
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?)
@@ -210,13 +252,77 @@ fn record_from_row(row: &Row<'_>) -> rusqlite::Result<Record> {
         id: RiftId::from_stored(row.get(0)?),
         parent_id: row.get::<_, Option<String>>(1)?.map(RiftId::from_stored),
         path: PathBuf::from(row.get::<_, String>(2)?),
+        git_storage_mode: GitStorageMode::from_stored(row.get::<_, String>(3)?),
+        shared_git_dir: optional_path(row.get(4)?),
     })
+}
+
+fn migrate(database: &Connection) -> Result<()> {
+    ensure_column(
+        database,
+        "git_storage_mode",
+        "ALTER TABLE rift ADD COLUMN git_storage_mode TEXT NOT NULL DEFAULT 'inline'",
+    )?;
+    ensure_column(
+        database,
+        "shared_git_dir",
+        "ALTER TABLE rift ADD COLUMN shared_git_dir TEXT",
+    )?;
+    ensure_column(
+        database,
+        "git_worktree_dir",
+        "ALTER TABLE rift ADD COLUMN git_worktree_dir TEXT",
+    )?;
+    ensure_table_column(
+        database,
+        "trash",
+        "shared_git_dir",
+        "ALTER TABLE trash ADD COLUMN shared_git_dir TEXT",
+    )?;
+    ensure_table_column(
+        database,
+        "trash",
+        "git_worktree_dir",
+        "ALTER TABLE trash ADD COLUMN git_worktree_dir TEXT",
+    )?;
+    Ok(())
+}
+
+fn ensure_column(database: &Connection, column: &str, statement: &str) -> Result<()> {
+    ensure_table_column(database, "rift", column, statement)
+}
+
+fn ensure_table_column(
+    database: &Connection,
+    table: &str,
+    column: &str,
+    statement: &str,
+) -> Result<()> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let exists = database
+        .prepare(&pragma)?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?
+        .iter()
+        .any(|name| name == column);
+    if !exists {
+        database.execute(statement, [])?;
+    }
+    Ok(())
 }
 
 fn path_text(path: &Path) -> Result<String> {
     path.to_str()
         .map(ToOwned::to_owned)
         .ok_or_else(|| Error::Path(format!("path is not valid UTF-8: {}", path.display())))
+}
+
+fn optional_path_text(path: Option<&Path>) -> Result<Option<String>> {
+    path.map(path_text).transpose()
+}
+
+fn optional_path(path: Option<String>) -> Option<PathBuf> {
+    path.map(PathBuf::from)
 }
 
 fn timestamp() -> i64 {
@@ -264,13 +370,38 @@ mod tests {
         let child_id = id("child");
         let sibling_id = id("sibling");
         let grandchild_id = id("grandchild");
-        registry.insert_root(&root_id, &root).unwrap();
-        registry.insert_child(&child_id, &root_id, &child).unwrap();
         registry
-            .insert_child(&sibling_id, &root_id, &sibling)
+            .insert_root(&root_id, &root, GitStorageMode::Inline, None)
             .unwrap();
         registry
-            .insert_child(&grandchild_id, &child_id, &grandchild)
+            .insert_child(
+                &child_id,
+                &root_id,
+                &child,
+                GitStorageMode::Inline,
+                None,
+                None,
+            )
+            .unwrap();
+        registry
+            .insert_child(
+                &sibling_id,
+                &root_id,
+                &sibling,
+                GitStorageMode::Inline,
+                None,
+                None,
+            )
+            .unwrap();
+        registry
+            .insert_child(
+                &grandchild_id,
+                &child_id,
+                &grandchild,
+                GitStorageMode::Inline,
+                None,
+                None,
+            )
             .unwrap();
 
         let subtree = registry
@@ -302,8 +433,19 @@ mod tests {
         let trash = temp.path().join(".trash/child");
         let root_id = id("root");
         let child_id = id("child");
-        registry.insert_root(&root_id, &root).unwrap();
-        registry.insert_child(&child_id, &root_id, &child).unwrap();
+        registry
+            .insert_root(&root_id, &root, GitStorageMode::Inline, None)
+            .unwrap();
+        registry
+            .insert_child(
+                &child_id,
+                &root_id,
+                &child,
+                GitStorageMode::Inline,
+                None,
+                None,
+            )
+            .unwrap();
 
         registry
             .trash_moved(&[MovedRecord {
@@ -320,8 +462,111 @@ mod tests {
             vec![PathRecord {
                 id: child_id,
                 path: trash,
+                shared_git_dir: None,
+                git_worktree_dir: None,
             }]
         );
+    }
+
+    #[test]
+    fn trash_moved_preserves_git_metadata() {
+        let (temp, mut registry) = registry();
+        let root = temp.path().join("root");
+        let child = temp.path().join("child");
+        let trash = temp.path().join(".trash/child");
+        let root_git = temp.path().join("rift/repos/root/git");
+        let child_git = root_git.join("worktrees/child");
+        let root_id = id("root");
+        let child_id = id("child");
+        registry
+            .insert_root(
+                &root_id,
+                &root,
+                GitStorageMode::SharedWorktrees,
+                Some(&root_git),
+            )
+            .unwrap();
+        registry
+            .insert_child(
+                &child_id,
+                &root_id,
+                &child,
+                GitStorageMode::SharedWorktrees,
+                Some(&root_git),
+                Some(&child_git),
+            )
+            .unwrap();
+
+        registry
+            .trash_moved(&[MovedRecord {
+                id: child_id.clone(),
+                original_path: child,
+                trash_path: trash.clone(),
+            }])
+            .unwrap();
+
+        assert_eq!(
+            registry.trashed_paths().unwrap(),
+            vec![PathRecord {
+                id: child_id,
+                path: trash,
+                shared_git_dir: Some(root_git),
+                git_worktree_dir: Some(child_git),
+            }]
+        );
+    }
+
+    #[test]
+    fn git_storage_metadata_round_trips() {
+        let (temp, registry) = registry();
+        let root = temp.path().join("root");
+        let child = temp.path().join("child");
+        let root_git = temp.path().join("rift/repos/root/git");
+        let child_git = root_git.join("worktrees/child");
+        let root_id = id("root");
+        let child_id = id("child");
+
+        registry
+            .insert_root(
+                &root_id,
+                &root,
+                GitStorageMode::SharedWorktrees,
+                Some(&root_git),
+            )
+            .unwrap();
+        registry
+            .insert_child(
+                &child_id,
+                &root_id,
+                &child,
+                GitStorageMode::SharedWorktrees,
+                Some(&root_git),
+                Some(&child_git),
+            )
+            .unwrap();
+
+        let root_record = registry.record_id(&root_id).unwrap().unwrap();
+        let child_record = registry.record_id(&child_id).unwrap().unwrap();
+
+        assert_eq!(
+            root_record.git_storage_mode,
+            GitStorageMode::SharedWorktrees
+        );
+        assert_eq!(root_record.shared_git_dir, Some(root_git.clone()));
+        assert_eq!(
+            child_record.git_storage_mode,
+            GitStorageMode::SharedWorktrees
+        );
+        assert_eq!(child_record.shared_git_dir, Some(root_git.clone()));
+
+        let subtree = registry
+            .subtree(&root_id, SubtreeScope::IncludingRoot)
+            .unwrap();
+        assert!(subtree.iter().any(|record| {
+            record.id == child_id
+                && record.shared_git_dir == Some(root_git.clone())
+                && record.git_worktree_dir == Some(child_git.clone())
+        }));
     }
 
     fn id(value: &str) -> RiftId {

--- a/crates/core/src/worktree.rs
+++ b/crates/core/src/worktree.rs
@@ -1,0 +1,487 @@
+use crate::git;
+use crate::id::RiftId;
+use crate::{Error, Result};
+use std::fs;
+use std::io;
+use std::path::Component;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(crate) struct SharedGitRoot {
+    pub(crate) git_dir: PathBuf,
+}
+
+pub(crate) struct RegisteredWorktree {
+    pub(crate) git_dir: PathBuf,
+}
+
+pub(crate) fn shared_git_dir_for(repo_storage: &Path, root_id: &RiftId) -> PathBuf {
+    repo_storage.join(root_id.as_str()).join("git")
+}
+
+pub(crate) fn initialize_root(
+    path: &Path,
+    root_id: &RiftId,
+    repo_storage: &Path,
+) -> Result<SharedGitRoot> {
+    let inline_git = path.join(".git");
+    if !real_directory(&inline_git)? {
+        return Err(Error::UnsafeGit(
+            "rift init --worktrees requires a repository with an inline .git directory".into(),
+        ));
+    }
+    ensure_toplevel(path)?;
+
+    let final_git = shared_git_dir_for(repo_storage, root_id);
+    let final_parent = final_git
+        .parent()
+        .ok_or_else(|| Error::Path(format!("Git dir has no parent: {}", final_git.display())))?;
+    let final_parent = final_parent.to_path_buf();
+    let staging_parent = final_parent.with_extension("tmp");
+    let staging_git = staging_parent.join("git");
+    if final_parent.exists() || staging_parent.exists() {
+        return Err(Error::AlreadyExists(final_parent.to_path_buf()));
+    }
+    let repos = final_parent.parent().ok_or_else(|| {
+        Error::Path(format!(
+            "repository storage has no parent: {}",
+            final_parent.display()
+        ))
+    })?;
+    let result = (|| {
+        fs::create_dir_all(repos)?;
+        fs::create_dir_all(&staging_parent)?;
+        fs::rename(&inline_git, &staging_git)?;
+        write_git_pointer(&inline_git, &staging_git)?;
+        configure_external_root(&staging_git, path)?;
+        validate_worktree(path)?;
+        fs::rename(&staging_parent, &final_parent)?;
+        write_git_pointer(&inline_git, &final_git)?;
+        configure_external_root(&final_git, path)?;
+        validate_worktree(path)?;
+        Ok(SharedGitRoot {
+            git_dir: final_git.clone(),
+        })
+    })();
+
+    if result.is_err() {
+        rollback_initialize_root(
+            &inline_git,
+            &staging_git,
+            &final_git,
+            &staging_parent,
+            &final_parent,
+        );
+    }
+    result
+}
+
+pub(crate) fn ensure_head_commit(path: &Path) -> Result<()> {
+    match head_state(path)? {
+        HeadState::Commit(_) => Ok(()),
+        HeadState::Symbolic(_) => Err(Error::UnsafeGit(
+            "rift init --worktrees requires a repository with at least one commit".into(),
+        )),
+    }
+}
+
+pub(crate) fn register_cow_clone(
+    root_git_dir: &Path,
+    source: &Path,
+    destination: &Path,
+    id: &RiftId,
+) -> Result<RegisteredWorktree> {
+    let head = head_state(source)?;
+    let git_dir = root_git_dir.join("worktrees").join(id.as_str());
+    if git_dir.exists() {
+        return Err(Error::AlreadyExists(git_dir));
+    }
+    let result = (|| {
+        fs::create_dir_all(&git_dir)?;
+        remove_copied_git_entry(destination)?;
+        write_git_pointer(&destination.join(".git"), &git_dir)?;
+        fs::write(
+            git_dir.join("gitdir"),
+            format!("{}\n", destination.join(".git").display()),
+        )?;
+        fs::write(git_dir.join("commondir"), "../..\n")?;
+        fs::write(git_dir.join("HEAD"), head.contents())?;
+        if !copy_source_index(source, &git_dir)? {
+            if let HeadState::Commit(commit) = &head {
+                run_worktree(
+                    destination,
+                    &["reset", "--mixed", "--quiet", commit.as_str()],
+                )?;
+            }
+        }
+        validate_worktree(destination)?;
+        validate_worktree_list(root_git_dir)?;
+        Ok(RegisteredWorktree {
+            git_dir: git_dir.clone(),
+        })
+    })();
+    if result.is_err() {
+        let _ = remove_registered_worktree(&git_dir);
+    }
+    result
+}
+
+pub(crate) fn remove_registered_worktree(git_dir: &Path) -> Result<()> {
+    if let Ok(metadata) = fs::symlink_metadata(git_dir) {
+        if metadata.is_dir() {
+            fs::remove_dir_all(git_dir)?;
+        } else {
+            fs::remove_file(git_dir)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn remove_shared_git_storage(shared_git_dir: &Path, root_id: &RiftId) -> Result<()> {
+    let Some(parent) = shared_git_dir.parent() else {
+        return Err(Error::Path(format!(
+            "shared Git dir has no parent: {}",
+            shared_git_dir.display()
+        )));
+    };
+    let unsafe_components = shared_git_dir
+        .components()
+        .any(|component| matches!(component, Component::ParentDir));
+    if unsafe_components
+        || shared_git_dir.file_name() != Some(std::ffi::OsStr::new("git"))
+        || parent.file_name() != Some(std::ffi::OsStr::new(root_id.as_str()))
+    {
+        return Err(Error::UnsafeGit(format!(
+            "refusing to remove shared Git storage outside Rift repository storage: {}",
+            shared_git_dir.display()
+        )));
+    }
+    if parent.exists() {
+        fs::remove_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_inline_root_restore(worktree: &Path, shared_git_dir: &Path) -> Result<()> {
+    let git = worktree.join(".git");
+    if git.exists() {
+        let metadata = fs::symlink_metadata(&git)?;
+        if metadata.is_dir() && shared_git_dir.exists() {
+            return Err(Error::UnsafeGit(format!(
+                "cannot restore inline Git metadata over existing directory: {}",
+                git.display()
+            )));
+        }
+    }
+    if !git.is_dir() && !shared_git_dir.exists() {
+        return Err(Error::UnsafeGit(format!(
+            "shared Git directory is missing: {}",
+            shared_git_dir.display()
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn restore_inline_root(worktree: &Path, shared_git_dir: &Path) -> Result<()> {
+    validate_inline_root_restore(worktree, shared_git_dir)?;
+    let git = worktree.join(".git");
+    if git.exists() {
+        let metadata = fs::symlink_metadata(&git)?;
+        if metadata.is_dir() {
+            if !shared_git_dir.exists() {
+                configure_inline_root(&git)?;
+                remove_empty_storage_parent(shared_git_dir);
+                return Ok(());
+            }
+            return Err(Error::UnsafeGit(format!(
+                "cannot restore inline Git metadata over existing directory: {}",
+                git.display()
+            )));
+        }
+        fs::remove_file(&git)?;
+    }
+    if let Err(error) = move_dir(shared_git_dir, &git) {
+        let _ = write_git_pointer(&git, shared_git_dir);
+        return Err(error);
+    }
+    configure_inline_root(&git)?;
+    remove_empty_storage_parent(shared_git_dir);
+    Ok(())
+}
+
+pub(crate) fn prune(root_git_dir: &Path) -> Result<()> {
+    let output = Command::new("git")
+        .arg("--git-dir")
+        .arg(root_git_dir)
+        .args(["worktree", "prune"])
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::UnsafeGit(format!(
+            "failed to prune Git worktrees: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_worktree_dir(root_git_dir: &Path, git_dir: &Path) -> Result<()> {
+    let worktrees = root_git_dir.join("worktrees");
+    let unsafe_components = root_git_dir
+        .components()
+        .chain(git_dir.components())
+        .any(|component| matches!(component, Component::ParentDir));
+    if unsafe_components || git_dir.parent() != Some(worktrees.as_path()) {
+        return Err(Error::UnsafeGit(format!(
+            "refusing to remove Git metadata outside Rift worktree storage: {}",
+            git_dir.display()
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_toplevel(path: &Path) -> Result<()> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::UnsafeGit(format!(
+            "failed to resolve Git root: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let top = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim().to_owned());
+    if fs::canonicalize(path)? != fs::canonicalize(top)? {
+        return Err(Error::UnsafeGit(
+            "rift init --worktrees must run at the repository root".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn configure_external_root(git_dir: &Path, worktree: &Path) -> Result<()> {
+    let worktree = worktree.to_string_lossy().into_owned();
+    run_git(git_dir, &["config", "core.worktree", &worktree])?;
+    run_git(git_dir, &["config", "core.bare", "false"])
+}
+
+fn validate_worktree(path: &Path) -> Result<()> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["status", "--porcelain"])
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::UnsafeGit(format!(
+            "Git worktree validation failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_worktree_list(root_git_dir: &Path) -> Result<()> {
+    run_git(root_git_dir, &["worktree", "list", "--porcelain"])
+}
+
+fn run_worktree(worktree: &Path, args: &[&str]) -> Result<()> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(worktree)
+        .args(args)
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::UnsafeGit(format!(
+            "Git command failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+fn run_git(git_dir: &Path, args: &[&str]) -> Result<()> {
+    let output = Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(args)
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::UnsafeGit(format!(
+            "Git command failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+enum HeadState {
+    Commit(String),
+    Symbolic(String),
+}
+
+impl HeadState {
+    fn contents(&self) -> String {
+        match self {
+            Self::Commit(commit) => format!("{commit}\n"),
+            Self::Symbolic(contents) => contents.clone(),
+        }
+    }
+}
+
+fn head_state(path: &Path) -> Result<HeadState> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--verify", "HEAD^{commit}"])
+        .output()?;
+    if output.status.success() {
+        return Ok(HeadState::Commit(
+            String::from_utf8_lossy(&output.stdout).trim().to_owned(),
+        ));
+    }
+    let Some(dirs) = git::resolve_dirs(path)? else {
+        return Err(Error::UnsafeGit("source is not a Git repository".into()));
+    };
+    let contents = fs::read_to_string(dirs.git_dir.join("HEAD"))?;
+    if contents.starts_with("ref: ") {
+        return Ok(HeadState::Symbolic(contents));
+    }
+    Err(Error::UnsafeGit(
+        "cannot resolve Git HEAD for worktree registration".into(),
+    ))
+}
+
+fn remove_copied_git_entry(destination: &Path) -> Result<()> {
+    let git = destination.join(".git");
+    let metadata = fs::symlink_metadata(&git)?;
+    if metadata.is_dir() {
+        fs::remove_dir_all(git)?;
+    } else {
+        fs::remove_file(git)?;
+    }
+    Ok(())
+}
+
+fn copy_source_index(source: &Path, git_dir: &Path) -> Result<bool> {
+    let Some(source_dirs) = git::resolve_dirs(source)? else {
+        return Err(Error::UnsafeGit("source is not a Git repository".into()));
+    };
+    let source_index = source_dirs.git_dir.join("index");
+    if source_index.exists() {
+        fs::copy(source_index, git_dir.join("index"))?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn write_git_pointer(path: &Path, git_dir: &Path) -> Result<()> {
+    fs::write(path, format!("gitdir: {}\n", git_dir.display()))?;
+    Ok(())
+}
+
+fn rollback_initialize_root(
+    inline_git: &Path,
+    staging_git: &Path,
+    final_git: &Path,
+    staging_parent: &Path,
+    final_parent: &Path,
+) {
+    let restored = if final_git.exists() {
+        restore_git_dir(final_git, inline_git).is_ok()
+    } else if staging_git.exists() {
+        restore_git_dir(staging_git, inline_git).is_ok()
+    } else {
+        false
+    };
+
+    if restored {
+        let _ = fs::remove_dir_all(staging_parent);
+        let _ = fs::remove_dir_all(final_parent);
+    }
+}
+
+fn restore_git_dir(source: &Path, destination: &Path) -> Result<()> {
+    if destination.exists() {
+        let metadata = fs::symlink_metadata(destination)?;
+        if metadata.is_dir() {
+            return Err(Error::UnsafeGit(format!(
+                "cannot restore Git metadata over existing directory: {}",
+                destination.display()
+            )));
+        }
+        fs::remove_file(destination)?;
+    }
+    move_dir(source, destination)
+}
+
+fn configure_inline_root(git_dir: &Path) -> Result<()> {
+    let _ = Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["config", "--unset", "core.worktree"])
+        .status();
+    run_git(git_dir, &["config", "core.bare", "false"])
+}
+
+fn move_dir(source: &Path, destination: &Path) -> Result<()> {
+    match fs::rename(source, destination) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {
+            let temporary = destination.with_extension("rift-restore-tmp");
+            if temporary.exists() {
+                return Err(Error::AlreadyExists(temporary));
+            }
+            copy_dir_all(source, &temporary)?;
+            fs::rename(&temporary, destination)?;
+            fs::remove_dir_all(source)?;
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn copy_dir_all(source: &Path, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_all(&from, &to)?;
+        } else if file_type.is_symlink() {
+            copy_symlink(&from, &to)?;
+        } else {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_empty_storage_parent(shared_git_dir: &Path) {
+    if let Some(parent) = shared_git_dir.parent() {
+        let _ = fs::remove_dir(parent);
+    }
+}
+
+fn real_directory(path: &Path) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.is_dir() && !metadata.file_type().is_symlink()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(unix)]
+fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
+    let target = fs::read_link(source)?;
+    std::os::unix::fs::symlink(target, destination)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
+    fs::copy(source, destination)?;
+    Ok(())
+}

--- a/crates/core/src/worktree.rs
+++ b/crates/core/src/worktree.rs
@@ -2,7 +2,6 @@ use crate::git;
 use crate::id::RiftId;
 use crate::{Error, Result};
 use std::fs;
-use std::io;
 use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -25,6 +24,7 @@ pub(crate) fn initialize_root(
     path: &Path,
     root_id: &RiftId,
     repo_storage: &Path,
+    copy_directory: impl FnOnce(&Path, &Path) -> Result<()>,
 ) -> Result<SharedGitRoot> {
     let inline_git = path.join(".git");
     if !real_directory(&inline_git)? {
@@ -53,27 +53,18 @@ pub(crate) fn initialize_root(
     let result = (|| {
         fs::create_dir_all(repos)?;
         fs::create_dir_all(&staging_parent)?;
-        fs::rename(&inline_git, &staging_git)?;
-        write_git_pointer(&inline_git, &staging_git)?;
-        configure_external_root(&staging_git, path)?;
-        validate_worktree(path)?;
+        copy_directory(&inline_git, &staging_git)?;
+        configure_snapshot_root(&staging_git)?;
+        validate_snapshot_root(&staging_git)?;
         fs::rename(&staging_parent, &final_parent)?;
-        write_git_pointer(&inline_git, &final_git)?;
-        configure_external_root(&final_git, path)?;
-        validate_worktree(path)?;
+        validate_snapshot_root(&final_git)?;
         Ok(SharedGitRoot {
             git_dir: final_git.clone(),
         })
     })();
 
     if result.is_err() {
-        rollback_initialize_root(
-            &inline_git,
-            &staging_git,
-            &final_git,
-            &staging_parent,
-            &final_parent,
-        );
+        rollback_initialize_root(&staging_parent, &final_parent);
     }
     result
 }
@@ -94,6 +85,7 @@ pub(crate) fn register_cow_clone(
     id: &RiftId,
 ) -> Result<RegisteredWorktree> {
     let head = head_state(source)?;
+    import_source_head(root_git_dir, source, &head)?;
     let git_dir = root_git_dir.join("worktrees").join(id.as_str());
     if git_dir.exists() {
         return Err(Error::AlreadyExists(git_dir));
@@ -164,53 +156,6 @@ pub(crate) fn remove_shared_git_storage(shared_git_dir: &Path, root_id: &RiftId)
     Ok(())
 }
 
-pub(crate) fn validate_inline_root_restore(worktree: &Path, shared_git_dir: &Path) -> Result<()> {
-    let git = worktree.join(".git");
-    if git.exists() {
-        let metadata = fs::symlink_metadata(&git)?;
-        if metadata.is_dir() && shared_git_dir.exists() {
-            return Err(Error::UnsafeGit(format!(
-                "cannot restore inline Git metadata over existing directory: {}",
-                git.display()
-            )));
-        }
-    }
-    if !git.is_dir() && !shared_git_dir.exists() {
-        return Err(Error::UnsafeGit(format!(
-            "shared Git directory is missing: {}",
-            shared_git_dir.display()
-        )));
-    }
-    Ok(())
-}
-
-pub(crate) fn restore_inline_root(worktree: &Path, shared_git_dir: &Path) -> Result<()> {
-    validate_inline_root_restore(worktree, shared_git_dir)?;
-    let git = worktree.join(".git");
-    if git.exists() {
-        let metadata = fs::symlink_metadata(&git)?;
-        if metadata.is_dir() {
-            if !shared_git_dir.exists() {
-                configure_inline_root(&git)?;
-                remove_empty_storage_parent(shared_git_dir);
-                return Ok(());
-            }
-            return Err(Error::UnsafeGit(format!(
-                "cannot restore inline Git metadata over existing directory: {}",
-                git.display()
-            )));
-        }
-        fs::remove_file(&git)?;
-    }
-    if let Err(error) = move_dir(shared_git_dir, &git) {
-        let _ = write_git_pointer(&git, shared_git_dir);
-        return Err(error);
-    }
-    configure_inline_root(&git)?;
-    remove_empty_storage_parent(shared_git_dir);
-    Ok(())
-}
-
 pub(crate) fn prune(root_git_dir: &Path) -> Result<()> {
     let output = Command::new("git")
         .arg("--git-dir")
@@ -262,10 +207,13 @@ fn ensure_toplevel(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn configure_external_root(git_dir: &Path, worktree: &Path) -> Result<()> {
-    let worktree = worktree.to_string_lossy().into_owned();
-    run_git(git_dir, &["config", "core.worktree", &worktree])?;
-    run_git(git_dir, &["config", "core.bare", "false"])
+fn configure_snapshot_root(git_dir: &Path) -> Result<()> {
+    let _ = Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["config", "--unset", "core.worktree"])
+        .status();
+    run_git(git_dir, &["config", "core.bare", "true"])
 }
 
 fn validate_worktree(path: &Path) -> Result<()> {
@@ -283,8 +231,29 @@ fn validate_worktree(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn validate_snapshot_root(git_dir: &Path) -> Result<()> {
+    run_git(git_dir, &["rev-parse", "--is-bare-repository"])
+}
+
 fn validate_worktree_list(root_git_dir: &Path) -> Result<()> {
     run_git(root_git_dir, &["worktree", "list", "--porcelain"])
+}
+
+fn import_source_head(root_git_dir: &Path, source: &Path, head: &HeadState) -> Result<()> {
+    let Some(source_dirs) = git::resolve_dirs(source)? else {
+        return Err(Error::UnsafeGit("source is not a Git repository".into()));
+    };
+    if source_dirs.common_dir == root_git_dir {
+        return Ok(());
+    }
+    let HeadState::Commit(commit) = head else {
+        return Ok(());
+    };
+    if snapshot_has_commit(root_git_dir, commit)? {
+        return Ok(());
+    }
+    let source_repo = source.to_string_lossy().into_owned();
+    run_git(root_git_dir, &["fetch", "--quiet", "--no-tags", &source_repo, commit])
 }
 
 fn run_worktree(worktree: &Path, args: &[&str]) -> Result<()> {
@@ -315,6 +284,15 @@ fn run_git(git_dir: &Path, args: &[&str]) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+fn snapshot_has_commit(git_dir: &Path, commit: &str) -> Result<bool> {
+    let output = Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["cat-file", "-e", &format!("{commit}^{{commit}}")])
+        .output()?;
+    Ok(output.status.success())
 }
 
 enum HeadState {
@@ -382,108 +360,15 @@ fn write_git_pointer(path: &Path, git_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn rollback_initialize_root(
-    inline_git: &Path,
-    staging_git: &Path,
-    final_git: &Path,
-    staging_parent: &Path,
-    final_parent: &Path,
-) {
-    let restored = if final_git.exists() {
-        restore_git_dir(final_git, inline_git).is_ok()
-    } else if staging_git.exists() {
-        restore_git_dir(staging_git, inline_git).is_ok()
-    } else {
-        false
-    };
-
-    if restored {
-        let _ = fs::remove_dir_all(staging_parent);
-        let _ = fs::remove_dir_all(final_parent);
-    }
-}
-
-fn restore_git_dir(source: &Path, destination: &Path) -> Result<()> {
-    if destination.exists() {
-        let metadata = fs::symlink_metadata(destination)?;
-        if metadata.is_dir() {
-            return Err(Error::UnsafeGit(format!(
-                "cannot restore Git metadata over existing directory: {}",
-                destination.display()
-            )));
-        }
-        fs::remove_file(destination)?;
-    }
-    move_dir(source, destination)
-}
-
-fn configure_inline_root(git_dir: &Path) -> Result<()> {
-    let _ = Command::new("git")
-        .arg("--git-dir")
-        .arg(git_dir)
-        .args(["config", "--unset", "core.worktree"])
-        .status();
-    run_git(git_dir, &["config", "core.bare", "false"])
-}
-
-fn move_dir(source: &Path, destination: &Path) -> Result<()> {
-    match fs::rename(source, destination) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {
-            let temporary = destination.with_extension("rift-restore-tmp");
-            if temporary.exists() {
-                return Err(Error::AlreadyExists(temporary));
-            }
-            copy_dir_all(source, &temporary)?;
-            fs::rename(&temporary, destination)?;
-            fs::remove_dir_all(source)?;
-            Ok(())
-        }
-        Err(error) => Err(error.into()),
-    }
-}
-
-fn copy_dir_all(source: &Path, destination: &Path) -> Result<()> {
-    fs::create_dir_all(destination)?;
-    for entry in fs::read_dir(source)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let from = entry.path();
-        let to = destination.join(entry.file_name());
-        if file_type.is_dir() {
-            copy_dir_all(&from, &to)?;
-        } else if file_type.is_symlink() {
-            copy_symlink(&from, &to)?;
-        } else {
-            fs::copy(&from, &to)?;
-        }
-    }
-    Ok(())
-}
-
-fn remove_empty_storage_parent(shared_git_dir: &Path) {
-    if let Some(parent) = shared_git_dir.parent() {
-        let _ = fs::remove_dir(parent);
-    }
+fn rollback_initialize_root(staging_parent: &Path, final_parent: &Path) {
+    let _ = fs::remove_dir_all(staging_parent);
+    let _ = fs::remove_dir_all(final_parent);
 }
 
 fn real_directory(path: &Path) -> Result<bool> {
     match fs::symlink_metadata(path) {
         Ok(metadata) => Ok(metadata.is_dir() && !metadata.file_type().is_symlink()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(error) => Err(error.into()),
     }
-}
-
-#[cfg(unix)]
-fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
-    let target = fs::read_link(source)?;
-    std::os::unix::fs::symlink(target, destination)?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
-    fs::copy(source, destination)?;
-    Ok(())
 }

--- a/crates/core/src/worktree.rs
+++ b/crates/core/src/worktree.rs
@@ -7,6 +7,8 @@ use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+const SHARED_GIT_DIR_NAME: &str = "rift-manager";
+
 pub(crate) struct SharedGitRoot {
     pub(crate) git_dir: PathBuf,
 }
@@ -16,7 +18,7 @@ pub(crate) struct RegisteredWorktree {
 }
 
 pub(crate) fn shared_git_dir_for(repo_storage: &Path, root_id: &RiftId) -> PathBuf {
-    repo_storage.join(root_id.as_str()).join("git")
+    repo_storage.join(root_id.as_str()).join(SHARED_GIT_DIR_NAME)
 }
 
 pub(crate) fn initialize_root(
@@ -38,7 +40,7 @@ pub(crate) fn initialize_root(
         .ok_or_else(|| Error::Path(format!("Git dir has no parent: {}", final_git.display())))?;
     let final_parent = final_parent.to_path_buf();
     let staging_parent = final_parent.with_extension("tmp");
-    let staging_git = staging_parent.join("git");
+    let staging_git = staging_parent.join(SHARED_GIT_DIR_NAME);
     if final_parent.exists() || staging_parent.exists() {
         return Err(Error::AlreadyExists(final_parent.to_path_buf()));
     }
@@ -148,7 +150,7 @@ pub(crate) fn remove_shared_git_storage(shared_git_dir: &Path, root_id: &RiftId)
         .components()
         .any(|component| matches!(component, Component::ParentDir));
     if unsafe_components
-        || shared_git_dir.file_name() != Some(std::ffi::OsStr::new("git"))
+        || shared_git_dir.file_name() != Some(std::ffi::OsStr::new(SHARED_GIT_DIR_NAME))
         || parent.file_name() != Some(std::ffi::OsStr::new(root_id.as_str()))
     {
         return Err(Error::UnsafeGit(format!(

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -1,4 +1,4 @@
-use rift::{Create, Error, Manager};
+use rift::{Create, Error, Init, Manager};
 use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString, c_char};
 use std::path::PathBuf;
@@ -15,6 +15,7 @@ struct Request {
 enum Command {
     Init {
         at: PathBuf,
+        worktrees: Option<bool>,
     },
     Create {
         from: PathBuf,
@@ -105,8 +106,11 @@ fn execute(input: &str) -> Result<Value, Failure> {
         .map_or_else(Manager::open_default, Manager::open)
         .map_err(Failure::from)?;
     match request.command {
-        Command::Init { at } => manager
-            .init(at)
+        Command::Init { at, worktrees } => manager
+            .init_options(Init {
+                at,
+                worktrees: worktrees.unwrap_or(false),
+            })
             .map(|_| Value::Empty(()))
             .map_err(Failure::from),
         Command::Create { from, name, into } => manager

--- a/npm/rift-snapshot/bun/index.js
+++ b/npm/rift-snapshot/bun/index.js
@@ -47,8 +47,8 @@ export class RiftError extends Error {
   }
 }
 
-export function init({ at = process.cwd(), database } = {}) {
-  return call({ command: "init", at, database })
+export function init({ at = process.cwd(), worktrees = false, database } = {}) {
+  return call({ command: "init", at, worktrees, database })
 }
 
 export function create({ from = process.cwd(), name, into, database } = {}) {

--- a/npm/rift-snapshot/index.d.ts
+++ b/npm/rift-snapshot/index.d.ts
@@ -6,6 +6,10 @@ export interface AtOptions extends Options {
   at?: string
 }
 
+export interface InitOptions extends AtOptions {
+  worktrees?: boolean
+}
+
 export interface CreateOptions extends Options {
   from?: string
   name?: string
@@ -47,7 +51,7 @@ export class RiftError extends Error {
   constructor(input: { code: RiftErrorCode; message: string; path?: string })
 }
 
-export function init(options?: AtOptions): null
+export function init(options?: InitOptions): null
 export function create(options?: CreateOptions): string
 export function remove(options?: RemoveOptions & { all: true }): string[]
 export function remove(options?: RemoveOptions): void

--- a/npm/rift-snapshot/node/index.js
+++ b/npm/rift-snapshot/node/index.js
@@ -40,8 +40,8 @@ export class RiftError extends Error {
   }
 }
 
-export function init({ at = process.cwd(), database } = {}) {
-  return call({ command: "init", at, database })
+export function init({ at = process.cwd(), worktrees = false, database } = {}) {
+  return call({ command: "init", at, worktrees, database })
 }
 
 export function create({ from = process.cwd(), name, into, database } = {}) {

--- a/specs.md
+++ b/specs.md
@@ -11,6 +11,7 @@
 ```ts
 init(input: {
   at: AbsolutePath
+  worktrees?: boolean
 }): void
 ```
 
@@ -25,6 +26,7 @@ init(input: {
 - The CLI defaults `at` to the current working directory; by default it selects the nearest existing managed ancestor or nearest Git root, prints the selected path, and then invokes core `init` with that exact path. `--here` opts into selecting exactly the supplied path.
 - Calling `init` inside an already initialized workspace reports the existing root; if that root's `.rift` marker was deleted, `init` restores the marker using its existing registry identity.
 - After a conversion it tells the caller to re-enter the original path.
+- If `worktrees` is true, `at` must be a Git repository root with an inline `.git` directory. Rift moves that `.git` directory into its user data directory, writes a `.git` pointer file in the workspace, records the external shared Git directory in the registry, and future rifts from that root are registered as Git worktrees.
 
 ### `create`
 
@@ -133,7 +135,10 @@ CREATE TABLE rift (
   id TEXT PRIMARY KEY,
   parent_id TEXT REFERENCES rift(id) ON DELETE CASCADE,
   path TEXT NOT NULL UNIQUE,
-  created_at INTEGER NOT NULL
+  created_at INTEGER NOT NULL,
+  git_storage_mode TEXT NOT NULL DEFAULT 'inline',
+  shared_git_dir TEXT,
+  git_worktree_dir TEXT
 );
 
 CREATE INDEX rift_parent_id_idx ON rift(parent_id);
@@ -141,7 +146,9 @@ CREATE INDEX rift_parent_id_idx ON rift(parent_id);
 CREATE TABLE trash (
   id TEXT PRIMARY KEY,
   path TEXT NOT NULL UNIQUE,
-  removed_at INTEGER NOT NULL
+  removed_at INTEGER NOT NULL,
+  shared_git_dir TEXT,
+  git_worktree_dir TEXT
 );
 ```
 
@@ -167,10 +174,11 @@ When registering or creating from a Git repository:
 - If `HEAD` resolves to a commit, detach `HEAD` in the created destination at that same commit.
 - Preserve the copied index and working tree state while detaching.
 - If the repository has no commits yet, leave its unborn branch state unchanged because there is no commit to detach to.
+- If the registered root was initialized with `worktrees: true`, create the destination with the normal copy-on-write strategy, replace the copied `.git` pointer with a new per-worktree pointer, create the corresponding Git worktree metadata under the shared Git directory, and copy the source worktree index so staged state is preserved.
 
 Refuse creation from a Git repository when:
 
-- It is a linked Git worktree whose `.git` is not an independent directory.
+- It is a linked Git worktree whose `.git` is not an independent directory, unless the repository belongs to a Rift root initialized with `worktrees: true`.
 - A merge, rebase, cherry-pick, revert, or bisect is in progress.
 - Git lock or inconsistent index state makes an exact safe copy unclear.
 

--- a/specs.md
+++ b/specs.md
@@ -26,7 +26,7 @@ init(input: {
 - The CLI defaults `at` to the current working directory; by default it selects the nearest existing managed ancestor or nearest Git root, prints the selected path, and then invokes core `init` with that exact path. `--here` opts into selecting exactly the supplied path.
 - Calling `init` inside an already initialized workspace reports the existing root; if that root's `.rift` marker was deleted, `init` restores the marker using its existing registry identity.
 - After a conversion it tells the caller to re-enter the original path.
-- If `worktrees` is true, `at` must be a Git repository root with an inline `.git` directory. Rift moves that `.git` directory into its user data directory, writes a `.git` pointer file in the workspace, records the external shared Git directory in the registry, and future rifts from that root are registered as Git worktrees. The shared storage directory is named `rift-manager`.
+- If `worktrees` is true, `at` must be a Git repository root with an inline `.git` directory. Rift snapshots that `.git` directory into its user data directory, leaves the workspace `.git` directory untouched, records the forked shared Git directory in the registry, and future rifts from that root are registered as Git worktrees against that snapshot. The shared storage directory is named `rift-manager`.
 
 ### `create`
 
@@ -174,7 +174,7 @@ When registering or creating from a Git repository:
 - If `HEAD` resolves to a commit, detach `HEAD` in the created destination at that same commit.
 - Preserve the copied index and working tree state while detaching.
 - If the repository has no commits yet, leave its unborn branch state unchanged because there is no commit to detach to.
-- If the registered root was initialized with `worktrees: true`, create the destination with the normal copy-on-write strategy, replace the copied `.git` pointer with a new per-worktree pointer, create the corresponding Git worktree metadata under the shared Git directory, and copy the source worktree index so staged state is preserved. Shared Git storage lives under `rift-manager`.
+- If the registered root was initialized with `worktrees: true`, create the destination with the normal copy-on-write strategy, replace the copied `.git` directory with a new per-worktree pointer, create the corresponding Git worktree metadata under the shared Git snapshot, and copy the source worktree index so staged state is preserved. When the source is the untouched root repository and its current `HEAD` commit is newer than the stored snapshot, import that commit object into the shared snapshot before registering the new worktree. Shared Git storage lives under `rift-manager`.
 
 Refuse creation from a Git repository when:
 

--- a/specs.md
+++ b/specs.md
@@ -26,7 +26,7 @@ init(input: {
 - The CLI defaults `at` to the current working directory; by default it selects the nearest existing managed ancestor or nearest Git root, prints the selected path, and then invokes core `init` with that exact path. `--here` opts into selecting exactly the supplied path.
 - Calling `init` inside an already initialized workspace reports the existing root; if that root's `.rift` marker was deleted, `init` restores the marker using its existing registry identity.
 - After a conversion it tells the caller to re-enter the original path.
-- If `worktrees` is true, `at` must be a Git repository root with an inline `.git` directory. Rift moves that `.git` directory into its user data directory, writes a `.git` pointer file in the workspace, records the external shared Git directory in the registry, and future rifts from that root are registered as Git worktrees.
+- If `worktrees` is true, `at` must be a Git repository root with an inline `.git` directory. Rift moves that `.git` directory into its user data directory, writes a `.git` pointer file in the workspace, records the external shared Git directory in the registry, and future rifts from that root are registered as Git worktrees. The shared storage directory is named `rift-manager`.
 
 ### `create`
 
@@ -174,7 +174,7 @@ When registering or creating from a Git repository:
 - If `HEAD` resolves to a commit, detach `HEAD` in the created destination at that same commit.
 - Preserve the copied index and working tree state while detaching.
 - If the repository has no commits yet, leave its unborn branch state unchanged because there is no commit to detach to.
-- If the registered root was initialized with `worktrees: true`, create the destination with the normal copy-on-write strategy, replace the copied `.git` pointer with a new per-worktree pointer, create the corresponding Git worktree metadata under the shared Git directory, and copy the source worktree index so staged state is preserved.
+- If the registered root was initialized with `worktrees: true`, create the destination with the normal copy-on-write strategy, replace the copied `.git` pointer with a new per-worktree pointer, create the corresponding Git worktree metadata under the shared Git directory, and copy the source worktree index so staged state is preserved. Shared Git storage lives under `rift-manager`.
 
 Refuse creation from a Git repository when:
 


### PR DESCRIPTION
When initialized with `rift init --worktrees`, all rifts are created as worktrees.

To achieve this, rift stores the root Git repo in shared storage and registers each new rift as a worktree. This doesn't mess with `.git/` in the directory rift was initialized in. I find this to be a good compromise of following the spirit of rift and actually supporting worktrees without doing crazy git manipulation.

Rift is already saving me a decent amount of headache related to npm packages and ignored files. My personal workflow is stacked pr's adjacent using lazygit so I like having worktrees for things like cherry picking and rebasing. I assume there's others that would find rift more useful with worktree registration.

I've been dogfooding this for the last day or so. Not noticing any perf degradations on a 4m loc with 40k commits on main.