### PR TITLE
feat: add postclone hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
  "ulid",
  "walkdir",
 ]
@@ -821,6 +822,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +924,47 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "ulid"
@@ -1112,6 +1163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.20"
 thiserror = "2.0"
+toml = "0.8"
 ulid = "1.2"
 walkdir = "2.5"

--- a/README.md
+++ b/README.md
@@ -50,13 +50,31 @@ On Linux, first initialization of an ordinary btrfs directory performs a reflink
 rift create
 rift create --name parser-fix
 rift create --into /fast/rifts
+rift create --copy-all
+rift create --no-hooks
 ```
 
 `rift create` searches upward for `.rift`, copies that managed workspace, records the immediate parent, and prints the new workspace path to stdout.
 
-On btrfs, it creates a writable subvolume snapshot. On other reflink-capable Linux filesystems, it reflink-clones the directory tree. On macOS, it uses APFS `clonefile`.
+By default, creation omits heavyweight regenerable dependency and build artifacts such as `node_modules`, `target`, virtualenvs, framework caches, `dist`, `build`, and `coverage`. Manifests and lockfiles are preserved. Use `--copy-all` to keep the previous exact-copy behavior.
+
+On btrfs, exact copies use writable subvolume snapshots and filtered copies use a reflink import into a new subvolume. On other reflink-capable Linux filesystems, Rift reflink-clones the selected directory tree. On macOS, exact copies use APFS `clonefile`, and filtered copies clone included entries.
 
 When the workspace is a Git repository, the new workspace has detached `HEAD` and retains index and working-tree state.
+
+If the source contains `.rift.toml`, `rift create` runs configured postclone hooks after the workspace is copied, registered, and prepared. Use `--no-hooks` to skip them.
+
+```toml
+version = 1
+
+[[hooks.postclone]]
+run = "pnpm install --frozen-lockfile"
+
+[[hooks.postclone]]
+run = "pnpm run codegen"
+```
+
+Postclone commands run in the new workspace root. If a hook fails, the workspace remains registered and `rift create` exits with an error.
 
 ### List And Ancestors
 
@@ -131,7 +149,7 @@ With Node's permission model, also pass `--allow-ffi`.
 
 ```ts
 init(options?: { at?: string; database?: string }): null
-create(options?: { from?: string; name?: string; into?: string; database?: string }): string
+create(options?: { from?: string; name?: string; into?: string; copyAll?: boolean; hooks?: boolean; database?: string }): string
 remove(options?: { at?: string; all?: false; database?: string }): void
 remove(options: { at?: string; all: true; database?: string }): string[]
 list(options?: { of?: string; database?: string }): string[]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
-use rift::{CopyMode, Create, HookMode, InitProgress, Manager};
+use rift::{CopyMode, Create, CreateOptions, HookMode, InitProgress, Manager};
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -213,10 +213,11 @@ fn run() -> Result<()> {
             copy_all,
             no_hooks,
         } => {
-            let destination = manager.create(
+            let destination = manager.create_with_options(
                 Create::new(from.unwrap_or(std::env::current_dir()?))
                     .with_name(name)
-                    .with_storage(into)
+                    .with_storage(into),
+                CreateOptions::default()
                     .copy_mode(if copy_all {
                         CopyMode::All
                     } else {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
-use rift::{Create, InitProgress, Manager};
+use rift::{CopyMode, Create, HookMode, InitProgress, Manager};
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -96,6 +96,10 @@ enum Command {
         name: Option<String>,
         #[arg(long)]
         into: Option<PathBuf>,
+        #[arg(long)]
+        copy_all: bool,
+        #[arg(long)]
+        no_hooks: bool,
     },
     Remove {
         at: Option<PathBuf>,
@@ -202,12 +206,28 @@ fn run() -> Result<()> {
             }
             Ok(())
         }
-        Command::Create { from, name, into } => {
-            let destination = manager.create(Create {
-                from: from.unwrap_or(std::env::current_dir()?),
-                name,
-                into,
-            })?;
+        Command::Create {
+            from,
+            name,
+            into,
+            copy_all,
+            no_hooks,
+        } => {
+            let destination = manager.create(
+                Create::new(from.unwrap_or(std::env::current_dir()?))
+                    .with_name(name)
+                    .with_storage(into)
+                    .copy_mode(if copy_all {
+                        CopyMode::All
+                    } else {
+                        CopyMode::Filtered
+                    })
+                    .hook_mode(if no_hooks {
+                        HookMode::Skip
+                    } else {
+                        HookMode::Run
+                    }),
+            )?;
             if cli.shell_cwd {
                 eprintln!("created {}", destination.display());
             }
@@ -374,6 +394,28 @@ mod tests {
             CliError::ForceRequired.to_string(),
             "This is the root workspace.\n\nUnregistering it removes Rift metadata and trashes all child rifts.\nRun `rift remove -f` to continue."
         );
+    }
+
+    #[test]
+    fn create_command_accepts_copy_and_hook_flags() {
+        let cli = Cli::try_parse_from([
+            "rift",
+            "create",
+            "--name",
+            "child",
+            "--copy-all",
+            "--no-hooks",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Command::Create {
+                copy_all: true,
+                no_hooks: true,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,7 +9,9 @@ dirs.workspace = true
 libc.workspace = true
 rand.workspace = true
 rusqlite.workspace = true
+serde.workspace = true
 thiserror.workspace = true
+toml.workspace = true
 ulid.workspace = true
 walkdir.workspace = true
 
@@ -17,7 +19,6 @@ walkdir.workspace = true
 git2 = { version = "0.20", default-features = false }
 
 [dev-dependencies]
-serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 

--- a/crates/core/benches/create.rs
+++ b/crates/core/benches/create.rs
@@ -1,4 +1,4 @@
-use rift::{Create, Manager};
+use rift::{Create, HookMode, Manager};
 use serde::Serialize;
 use std::env;
 use std::error::Error;
@@ -76,11 +76,11 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut samples_ms = Vec::with_capacity(samples);
     for sample in 1..=samples {
         let started = Instant::now();
-        let destination = manager.create(Create {
-            from: source.clone(),
-            name: Some(format!("benchmark-{process_id}-{run_id}-{sample}")),
-            into: None,
-        })?;
+        let destination = manager.create(
+            Create::new(source.clone())
+                .named(format!("benchmark-{process_id}-{run_id}-{sample}"))
+                .hook_mode(HookMode::Skip),
+        )?;
         let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
 
         println!(

--- a/crates/core/benches/create.rs
+++ b/crates/core/benches/create.rs
@@ -1,4 +1,4 @@
-use rift::{Create, HookMode, Manager};
+use rift::{Create, CreateOptions, HookMode, Manager};
 use serde::Serialize;
 use std::env;
 use std::error::Error;
@@ -76,10 +76,9 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut samples_ms = Vec::with_capacity(samples);
     for sample in 1..=samples {
         let started = Instant::now();
-        let destination = manager.create(
-            Create::new(source.clone())
-                .named(format!("benchmark-{process_id}-{run_id}-{sample}"))
-                .hook_mode(HookMode::Skip),
+        let destination = manager.create_with_options(
+            Create::new(source.clone()).named(format!("benchmark-{process_id}-{run_id}-{sample}")),
+            CreateOptions::default().hook_mode(HookMode::Skip),
         )?;
         let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,0 +1,150 @@
+use crate::{Error, Result};
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Default)]
+pub(crate) struct Config {
+    postclone: Vec<Postclone>,
+}
+
+impl Config {
+    pub(crate) fn load(workspace: &Path) -> Result<Self> {
+        let path = workspace.join(".rift.toml");
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        parse(&path, &fs::read_to_string(&path)?)
+    }
+
+    pub(crate) fn postclone(&self) -> &[Postclone] {
+        &self.postclone
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Postclone {
+    run: String,
+}
+
+impl Postclone {
+    pub(crate) fn run(&self) -> &str {
+        &self.run
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    version: u32,
+    #[serde(default)]
+    hooks: RawHooks,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawHooks {
+    #[serde(default)]
+    postclone: Vec<RawPostclone>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPostclone {
+    run: String,
+}
+
+fn parse(path: &Path, contents: &str) -> Result<Config> {
+    let raw = toml::from_str::<RawConfig>(contents)
+        .map_err(|error| invalid_config(path, error.to_string()))?;
+    if raw.version != 1 {
+        return Err(invalid_config(
+            path,
+            format!("unsupported config version {}", raw.version),
+        ));
+    }
+    raw.hooks
+        .postclone
+        .into_iter()
+        .map(|step| {
+            let run = step.run.trim().to_owned();
+            if run.is_empty() {
+                Err(invalid_config(path, "postclone run cannot be empty"))
+            } else {
+                Ok(Postclone { run })
+            }
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|postclone| Config { postclone })
+}
+
+fn invalid_config(path: &Path, message: impl Into<String>) -> Error {
+    Error::InvalidConfig {
+        path: PathBuf::from(path),
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ordered_postclone_steps() {
+        let config = parse(
+            Path::new(".rift.toml"),
+            r#"
+version = 1
+
+[[hooks.postclone]]
+run = "echo one"
+
+[[hooks.postclone]]
+run = "echo two"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config
+                .postclone()
+                .iter()
+                .map(Postclone::run)
+                .collect::<Vec<_>>(),
+            vec!["echo one", "echo two"]
+        );
+    }
+
+    #[test]
+    fn rejects_empty_steps() {
+        assert!(matches!(
+            parse(
+                Path::new(".rift.toml"),
+                r#"
+version = 1
+
+[[hooks.postclone]]
+run = " "
+"#,
+            ),
+            Err(Error::InvalidConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        assert!(matches!(
+            parse(
+                Path::new(".rift.toml"),
+                r#"
+version = 1
+
+[[hooks.postclone]]
+run = "echo ok"
+shell = "sh"
+"#,
+            ),
+            Err(Error::InvalidConfig { .. })
+        ));
+    }
+}

--- a/crates/core/src/filter.rs
+++ b/crates/core/src/filter.rs
@@ -1,0 +1,71 @@
+use std::ffi::OsStr;
+use std::path::{Component, Path};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct CopyFilter;
+
+impl CopyFilter {
+    pub(crate) fn excludes(self, path: &Path) -> bool {
+        let parts = path
+            .components()
+            .filter_map(|component| match component {
+                Component::Normal(part) => Some(part),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        parts.iter().any(|part| excludes_component(part))
+            || parts
+                .windows(2)
+                .any(|parts| matches_yarn_artifact(parts[0], parts[1]))
+    }
+}
+
+fn excludes_component(part: &OsStr) -> bool {
+    [
+        "node_modules",
+        ".pnpm-store",
+        "target",
+        ".venv",
+        "venv",
+        ".tox",
+        ".nox",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".next",
+        ".nuxt",
+        ".svelte-kit",
+        ".turbo",
+        ".vite",
+        ".parcel-cache",
+        ".cache",
+        "dist",
+        "build",
+        "coverage",
+    ]
+    .into_iter()
+    .any(|excluded| part == excluded)
+}
+
+fn matches_yarn_artifact(first: &OsStr, second: &OsStr) -> bool {
+    first == ".yarn"
+        && ["cache", "unplugged", "install-state.gz", "build-state.yml"]
+            .into_iter()
+            .any(|artifact| second == artifact)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn excludes_artifacts_at_any_depth() {
+        let filter = CopyFilter;
+
+        assert!(filter.excludes(Path::new("packages/app/node_modules/react/index.js")));
+        assert!(filter.excludes(Path::new("packages/app/.yarn/cache/react.zip")));
+        assert!(!filter.excludes(Path::new("packages/app/package-lock.json")));
+    }
+}

--- a/crates/core/src/hook.rs
+++ b/crates/core/src/hook.rs
@@ -1,0 +1,66 @@
+use crate::config::Postclone;
+use crate::id::RiftId;
+use crate::{Error, Result};
+use std::path::Path;
+use std::process::Command;
+
+pub(crate) fn run_postclone(
+    steps: &[Postclone],
+    source: &Path,
+    destination: &Path,
+    id: &RiftId,
+    parent_id: &RiftId,
+) -> Result<()> {
+    steps
+        .iter()
+        .map(Postclone::run)
+        .try_for_each(|command| run_step(command, source, destination, id, parent_id))
+}
+
+fn run_step(
+    command: &str,
+    source: &Path,
+    destination: &Path,
+    id: &RiftId,
+    parent_id: &RiftId,
+) -> Result<()> {
+    let status = shell_command(command)
+        .current_dir(destination)
+        .env("RIFT_SOURCE", source)
+        .env("RIFT_DESTINATION", destination)
+        .env("RIFT_ID", id.as_str())
+        .env("RIFT_PARENT_ID", parent_id.as_str())
+        .status()
+        .map_err(|error| hook_failed(destination, command, format!("failed to start: {error}")))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(hook_failed(
+            destination,
+            command,
+            format!("exited with {status}"),
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("cmd");
+    shell.args(["/C", command]);
+    shell
+}
+
+#[cfg(not(windows))]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("sh");
+    shell.args(["-c", command]);
+    shell
+}
+
+fn hook_failed(path: &Path, command: &str, message: String) -> Error {
+    Error::HookFailed {
+        path: path.to_path_buf(),
+        command: command.to_owned(),
+        message,
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,7 @@
+mod config;
+mod filter;
 mod git;
+mod hook;
 mod id;
 mod marker;
 mod name;
@@ -49,12 +52,83 @@ pub enum Error {
     MissingRift(PathBuf),
     #[error("cannot copy a workspace into itself: {0}")]
     InsideSource(PathBuf),
+    #[error("invalid rift config at {path}: {message}")]
+    InvalidConfig { path: PathBuf, message: String },
+    #[error("postclone hook failed at {path}: `{command}` {message}")]
+    HookFailed {
+        path: PathBuf,
+        command: String,
+        message: String,
+    },
 }
 
 pub struct Create {
     pub from: PathBuf,
     pub name: Option<String>,
     pub into: Option<PathBuf>,
+    pub copy_mode: CopyMode,
+    pub hook_mode: HookMode,
+}
+
+impl Create {
+    pub fn new(from: impl Into<PathBuf>) -> Self {
+        Self {
+            from: from.into(),
+            name: None,
+            into: None,
+            copy_mode: CopyMode::default(),
+            hook_mode: HookMode::default(),
+        }
+    }
+
+    pub fn named(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub fn with_name(mut self, name: Option<String>) -> Self {
+        self.name = name;
+        self
+    }
+
+    pub fn with_storage(mut self, into: Option<PathBuf>) -> Self {
+        self.into = into;
+        self
+    }
+
+    pub fn copy_mode(mut self, copy_mode: CopyMode) -> Self {
+        self.copy_mode = copy_mode;
+        self
+    }
+
+    pub fn hook_mode(mut self, hook_mode: HookMode) -> Self {
+        self.hook_mode = hook_mode;
+        self
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CopyMode {
+    Filtered,
+    All,
+}
+
+impl Default for CopyMode {
+    fn default() -> Self {
+        Self::Filtered
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HookMode {
+    Run,
+    Skip,
+}
+
+impl Default for HookMode {
+    fn default() -> Self {
+        Self::Run
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -128,15 +202,22 @@ impl Manager {
         if destination.exists() {
             return Err(Error::AlreadyExists(destination));
         }
+        let config = match input.hook_mode {
+            HookMode::Run => config::Config::load(&from)?,
+            HookMode::Skip => config::Config::default(),
+        };
 
-        if let Err(error) = self.strategy.copy_directory(&from, &destination) {
+        if let Err(error) = self
+            .strategy
+            .copy_directory(&from, &destination, input.copy_mode)
+        {
             if destination.exists() {
                 let _ = self.strategy.remove_directory(&destination);
             }
             return Err(error);
         }
 
-        let result = (|| {
+        let result: Result<()> = (|| {
             marker::write(&destination, &id)?;
             if git.is_repository() {
                 git::hide_marker(&destination)?;
@@ -146,12 +227,14 @@ impl Manager {
                 git::hide_marker(&from)?;
             }
             self.registry.insert_child(&id, &source.id, &destination)?;
-            Ok(destination.clone())
+            Ok(())
         })();
         if result.is_err() {
             let _ = self.strategy.remove_directory(&destination);
         }
-        result
+        result?;
+        hook::run_postclone(config.postclone(), &from, &destination, &id, &source.id)?;
+        Ok(destination)
     }
 
     pub fn init(&mut self, at: impl AsRef<Path>) -> Result<InitOutcome> {
@@ -440,853 +523,4 @@ fn trash_path(id: &RiftId, path: &Path) -> Result<PathBuf> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::strategy::{FailureStrategy, Strategy, TestStrategy};
-    use std::cell::Cell;
-    use std::process::Command;
-    use std::rc::Rc;
-    use tempfile::TempDir;
-    use ulid::Ulid;
-
-    fn manager(temp: &TempDir) -> Manager {
-        Manager::with_strategy(temp.path().join("registry.sqlite"), Box::new(TestStrategy)).unwrap()
-    }
-
-    fn source(temp: &TempDir) -> PathBuf {
-        let source = temp.path().join("app");
-        fs::create_dir(&source).unwrap();
-        fs::write(source.join("file.txt"), "hello").unwrap();
-        fs::canonicalize(source).unwrap()
-    }
-
-    fn marker_id(path: &Path) -> RiftId {
-        marker::read(path).unwrap().unwrap()
-    }
-
-    #[test]
-    fn create_tracks_parentage_and_default_storage() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-
-        let parent = source.parent().unwrap();
-        assert_eq!(first, parent.join(".rifts/app/first"));
-        assert_eq!(second, parent.join(".rifts/app/second"));
-        assert_ne!(
-            fs::read_to_string(source.join(".rift")).unwrap(),
-            fs::read_to_string(first.join(".rift")).unwrap()
-        );
-        assert_eq!(manager.list(&source).unwrap(), vec![first.clone()]);
-        assert_eq!(manager.ancestors(&second).unwrap(), vec![first, source]);
-    }
-
-    #[test]
-    fn init_registers_a_root_workspace_without_creating_a_child() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-
-        assert_eq!(manager.init(&source).unwrap(), InitOutcome::Registered);
-        assert!(source.join(".rift").exists());
-        assert!(manager.list(&source).unwrap().is_empty());
-        assert_eq!(
-            manager.init(&source).unwrap(),
-            InitOutcome::AlreadyInitialized
-        );
-    }
-
-    #[test]
-    fn init_reports_structured_registration_progress_when_requested() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        let mut progress = Vec::new();
-
-        manager
-            .init_with_progress(&source, |event| progress.push(event))
-            .unwrap();
-
-        assert_eq!(progress, vec![InitProgress::RegisteringWorkspace]);
-    }
-
-    #[test]
-    fn create_supports_custom_storage_and_rejects_invalid_destinations() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let custom = temp.path().join("custom");
-        let child = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("custom".into()),
-                into: Some(custom.clone()),
-            })
-            .unwrap();
-        assert_eq!(child, fs::canonicalize(&custom).unwrap().join("custom"));
-        assert!(matches!(
-            manager.create(Create {
-                from: source.clone(),
-                name: Some("custom".into()),
-                into: Some(custom),
-            }),
-            Err(Error::AlreadyExists(_))
-        ));
-        assert!(matches!(
-            manager.create(Create {
-                from: source.clone(),
-                name: Some("..".into()),
-                into: None,
-            }),
-            Err(Error::Path(_))
-        ));
-        assert!(matches!(
-            manager.create(Create {
-                from: source.clone(),
-                name: Some("inside".into()),
-                into: Some(source.join("nested")),
-            }),
-            Err(Error::InsideSource(_))
-        ));
-        assert!(matches!(
-            manager.create(Create {
-                from: source.join("file.txt"),
-                name: Some("file".into()),
-                into: None,
-            }),
-            Err(Error::Path(_))
-        ));
-    }
-
-    #[test]
-    fn corrupt_and_unknown_markers_are_rejected() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let nested = source.join("nested");
-        fs::create_dir(&nested).unwrap();
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        fs::write(source.join(".rift"), "unknown\n").unwrap();
-        assert!(matches!(
-            manager.list(&nested),
-            Err(Error::UnknownMarker(_))
-        ));
-
-        let id = manager.registry.record_at(&source).unwrap().unwrap().id;
-        fs::write(source.join(".rift"), format!("{id}\n")).unwrap();
-        let other = temp.path().join("other");
-        fs::create_dir(&other).unwrap();
-        fs::write(other.join(".rift"), format!("{id}\n")).unwrap();
-        assert!(matches!(
-            manager.list(&other),
-            Err(Error::MarkerMismatch(_))
-        ));
-    }
-
-    #[test]
-    fn removal_rejects_marker_mismatch_and_existing_trash_target() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let child = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("child".into()),
-                into: None,
-            })
-            .unwrap();
-        let id = marker_id(&child);
-        fs::write(child.join(".rift"), "wrong\n").unwrap();
-        assert!(matches!(
-            manager.remove(&child),
-            Err(Error::UnknownMarker(_))
-        ));
-        fs::write(
-            child.join(".rift"),
-            fs::read_to_string(source.join(".rift")).unwrap(),
-        )
-        .unwrap();
-        assert!(matches!(
-            manager.remove(&child),
-            Err(Error::MarkerMismatch(_))
-        ));
-        fs::write(child.join(".rift"), format!("{id}\n")).unwrap();
-        let trash = trash_path(&id, &child).unwrap();
-        fs::create_dir_all(&trash).unwrap();
-        assert!(matches!(
-            manager.remove(&child),
-            Err(Error::AlreadyExists(_))
-        ));
-    }
-
-    #[test]
-    fn gc_forgets_a_trashed_path_already_removed_on_disk() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let child = manager
-            .create(Create {
-                from: source,
-                name: Some("child".into()),
-                into: None,
-            })
-            .unwrap();
-        let id = marker_id(&child);
-        let trash = trash_path(&id, &child).unwrap();
-        manager.remove(&child).unwrap();
-        fs::remove_dir_all(&trash).unwrap();
-
-        assert_eq!(manager.gc().unwrap(), vec![trash]);
-    }
-
-    #[test]
-    fn operations_use_the_nearest_ancestor_marker() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let nested = source.join("packages/app");
-        fs::create_dir_all(&nested).unwrap();
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-
-        let child = manager
-            .create(Create {
-                from: nested,
-                name: Some("nested".into()),
-                into: None,
-            })
-            .unwrap();
-        fs::create_dir(child.join("deep")).unwrap();
-
-        assert_eq!(
-            manager.list(source.join("packages")).unwrap(),
-            vec![child.clone()]
-        );
-        assert_eq!(manager.ancestors(child.join("deep")).unwrap(), vec![source]);
-    }
-
-    #[test]
-    fn operations_without_a_marker_explain_how_to_initialize() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let nested = source.join("nested");
-        fs::create_dir(&nested).unwrap();
-        let manager = manager(&temp);
-
-        assert!(matches!(
-            manager.list(&nested),
-            Err(Error::WorkspaceNotInitialized(path)) if path == nested
-        ));
-    }
-
-    #[test]
-    fn init_restores_a_deleted_marker_for_an_existing_workspace() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let nested = source.join("nested");
-        fs::create_dir(&nested).unwrap();
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let id = fs::read_to_string(source.join(".rift")).unwrap();
-        fs::remove_file(source.join(".rift")).unwrap();
-
-        assert!(matches!(
-            manager.list(&nested),
-            Err(Error::MissingMarker(path)) if path == source
-        ));
-
-        manager.init(&source).unwrap();
-        assert_eq!(fs::read_to_string(source.join(".rift")).unwrap(), id);
-        assert!(manager.list(&nested).unwrap().is_empty());
-    }
-
-    struct InitializingStrategy {
-        initialized: Rc<Cell<bool>>,
-    }
-
-    impl Strategy for InitializingStrategy {
-        fn copy_directory(&self, _from: &Path, _to: &Path) -> Result<()> {
-            unreachable!()
-        }
-
-        fn initialize_directory(
-            &self,
-            _path: &Path,
-            _progress: &mut dyn FnMut(InitProgress),
-        ) -> Result<StrategyInit> {
-            self.initialized.set(true);
-            Ok(StrategyInit::Converted)
-        }
-    }
-
-    #[test]
-    fn init_continues_initialization_after_restoring_a_marker() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut registered = manager(&temp);
-        registered.init(&source).unwrap();
-        fs::remove_file(source.join(".rift")).unwrap();
-        drop(registered);
-        let initialized = Rc::new(Cell::new(false));
-        let mut manager = Manager::with_strategy(
-            temp.path().join("registry.sqlite"),
-            Box::new(InitializingStrategy {
-                initialized: initialized.clone(),
-            }),
-        )
-        .unwrap();
-
-        assert_eq!(manager.init(&source).unwrap(), InitOutcome::Converted);
-        assert!(initialized.get());
-        assert!(source.join(".rift").exists());
-    }
-
-    #[test]
-    fn init_registers_exactly_the_requested_directory() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let nested = source.join("nested");
-        fs::create_dir(&nested).unwrap();
-        run(&source, &["init"]);
-        let mut manager = manager(&temp);
-
-        manager.init(&nested).unwrap();
-        assert!(!source.join(".rift").exists());
-        assert!(nested.join(".rift").exists());
-    }
-
-    #[test]
-    fn create_generates_readable_names_independent_of_ulid_identity() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-
-        let destination = manager
-            .create(Create {
-                from: source,
-                name: None,
-                into: None,
-            })
-            .unwrap();
-        let name = destination.file_name().unwrap().to_str().unwrap();
-        let parts = name.split('-').collect::<Vec<_>>();
-        let id = fs::read_to_string(destination.join(".rift")).unwrap();
-        let id = id.trim();
-
-        assert_eq!(parts.len(), 2);
-        assert!(
-            parts[0]
-                .chars()
-                .all(|character| character.is_ascii_lowercase())
-        );
-        assert!(
-            parts[1]
-                .chars()
-                .all(|character| character.is_ascii_lowercase())
-        );
-        assert!(Ulid::from_string(id).is_ok());
-        assert_ne!(name, id);
-    }
-
-    #[test]
-    fn remove_trashes_a_full_subtree_and_gc_deletes_it() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-
-        let first_id = marker_id(&first);
-        let first_trash = trash_path(&first_id, &first).unwrap();
-        let second_id = marker_id(&second);
-        let second_trash = trash_path(&second_id, &second).unwrap();
-
-        manager.remove(&first).unwrap();
-
-        assert!(!first.exists());
-        assert!(!second.exists());
-        assert!(first_trash.exists());
-        assert!(second_trash.exists());
-        assert!(manager.list(&source).unwrap().is_empty());
-        let deleted = manager.gc().unwrap();
-        assert!(deleted.contains(&second_trash));
-        assert!(deleted.contains(&first_trash));
-        assert_eq!(deleted.len(), 2);
-        assert!(!first_trash.exists());
-        assert!(!second_trash.exists());
-    }
-
-    #[test]
-    fn remove_on_a_registered_root_unregisters_it_and_trashes_descendants() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-        let first_id = marker_id(&first);
-        let first_trash = trash_path(&first_id, &first).unwrap();
-        let second_id = marker_id(&second);
-        let second_trash = trash_path(&second_id, &second).unwrap();
-
-        manager.remove(&source).unwrap();
-
-        assert!(source.exists());
-        assert!(!source.join(".rift").exists());
-        assert!(!first.exists());
-        assert!(!second.exists());
-        assert!(first_trash.exists());
-        assert!(second_trash.exists());
-        assert!(matches!(
-            manager.list(&source),
-            Err(Error::WorkspaceNotInitialized(_))
-        ));
-        let deleted = manager.gc().unwrap();
-        assert!(deleted.contains(&first_trash));
-        assert!(deleted.contains(&second_trash));
-    }
-
-    #[test]
-    fn remove_on_a_registered_root_tolerates_missing_descendants() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        fs::remove_dir_all(&first).unwrap();
-
-        manager.remove(&source).unwrap();
-
-        assert!(source.exists());
-        assert!(!source.join(".rift").exists());
-        assert!(matches!(
-            manager.list(&source),
-            Err(Error::WorkspaceNotInitialized(_))
-        ));
-    }
-
-    #[test]
-    fn remove_all_deletes_descendants_and_preserves_the_selected_workspace() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-        let sibling = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("sibling".into()),
-                into: None,
-            })
-            .unwrap();
-        let first_id = marker_id(&first);
-        let first_trash = trash_path(&first_id, &first).unwrap();
-
-        let removed = manager.remove_all(&source).unwrap();
-        assert_eq!(removed[0], second);
-        assert!(removed.contains(&first));
-        assert!(removed.contains(&sibling));
-        assert_eq!(removed.len(), 3);
-        assert!(source.exists());
-        assert!(!first.exists());
-        assert!(first_trash.exists());
-        assert!(manager.list(&source).unwrap().is_empty());
-    }
-
-    #[test]
-    fn remove_all_preserves_a_nested_selected_rift() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source,
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-
-        assert_eq!(manager.remove_all(&first).unwrap(), vec![second]);
-        assert!(first.exists());
-        assert!(manager.list(&first).unwrap().is_empty());
-    }
-
-    #[test]
-    fn remove_refuses_a_subtree_with_an_unlinked_move() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-        fs::rename(&second, temp.path().join("moved")).unwrap();
-
-        assert!(matches!(manager.remove(&first), Err(Error::MissingRift(_))));
-        assert!(first.exists());
-    }
-
-    #[test]
-    fn gc_removes_trashed_entries() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-        let first_id = marker_id(&first);
-        let second_id = marker_id(&second);
-        let first_trash = trash_path(&first_id, &first).unwrap();
-        let second_trash = trash_path(&second_id, &second).unwrap();
-        manager.remove(&first).unwrap();
-
-        let deleted = manager.gc().unwrap();
-        assert!(deleted.contains(&second_trash));
-        assert!(deleted.contains(&first_trash));
-        assert_eq!(deleted.len(), 2);
-        assert!(manager.list(&source).unwrap().is_empty());
-    }
-
-    #[test]
-    fn gc_has_no_effect_on_active_rifts() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-        assert!(manager.gc().unwrap().is_empty());
-        assert_eq!(manager.ancestors(&second).unwrap(), vec![first, source]);
-    }
-
-    #[test]
-    fn gc_prunes_active_entries_deleted_outside_rift() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-        fs::remove_dir_all(&first).unwrap();
-        fs::remove_dir_all(&second).unwrap();
-
-        let removed = manager.gc().unwrap();
-        assert!(removed.contains(&first));
-        assert!(removed.contains(&second));
-        assert!(manager.list(&source).unwrap().is_empty());
-    }
-
-    #[test]
-    fn gc_preserves_missing_active_parent_with_an_existing_descendant() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        let first = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("first".into()),
-                into: None,
-            })
-            .unwrap();
-        let second = manager
-            .create(Create {
-                from: first.clone(),
-                name: Some("second".into()),
-                into: None,
-            })
-            .unwrap();
-        fs::remove_dir_all(&first).unwrap();
-
-        assert!(manager.gc().unwrap().is_empty());
-        assert_eq!(manager.list(&source).unwrap(), vec![first]);
-        assert_eq!(
-            manager.ancestors(&second).unwrap(),
-            vec![source.parent().unwrap().join(".rifts/app/first"), source]
-        );
-    }
-
-    #[test]
-    fn git_copy_detaches_head_and_preserves_dirty_state() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        run(&source, &["init"]);
-        run(&source, &["config", "user.email", "test@example.com"]);
-        run(&source, &["config", "user.name", "Test"]);
-        run(&source, &["add", "file.txt"]);
-        run(&source, &["commit", "-m", "initial"]);
-        fs::write(source.join("file.txt"), "changed").unwrap();
-        run(&source, &["add", "file.txt"]);
-        fs::write(source.join("untracked.txt"), "new").unwrap();
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-
-        let destination = manager
-            .create(Create {
-                from: source.clone(),
-                name: Some("git".into()),
-                into: None,
-            })
-            .unwrap();
-
-        let source_commit = Command::new("git")
-            .arg("-C")
-            .arg(&source)
-            .args(["rev-parse", "--verify", "HEAD^{commit}"])
-            .output()
-            .unwrap();
-        assert!(
-            !Command::new("git")
-                .arg("-C")
-                .arg(&destination)
-                .args(["symbolic-ref", "-q", "HEAD"])
-                .status()
-                .unwrap()
-                .success()
-        );
-        assert_eq!(
-            fs::read_to_string(destination.join(".git/HEAD")).unwrap(),
-            format!(
-                "{}\n",
-                String::from_utf8_lossy(&source_commit.stdout).trim()
-            )
-        );
-        let staged = Command::new("git")
-            .arg("-C")
-            .arg(&destination)
-            .args(["diff", "--cached", "--name-only"])
-            .output()
-            .unwrap();
-        assert!(String::from_utf8_lossy(&staged.stdout).contains("file.txt"));
-        assert!(destination.join("untracked.txt").exists());
-        let status = Command::new("git")
-            .arg("-C")
-            .arg(&destination)
-            .args(["status", "--porcelain", "--", ".rift"])
-            .output()
-            .unwrap();
-        assert!(status.stdout.is_empty());
-    }
-
-    #[test]
-    fn git_copy_peels_symbolic_tag_heads_to_commits() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        run(&source, &["init"]);
-        run(&source, &["config", "user.email", "test@example.com"]);
-        run(&source, &["config", "user.name", "Test"]);
-        run(&source, &["add", "file.txt"]);
-        run(&source, &["commit", "-m", "initial"]);
-        run(&source, &["tag", "-a", "release", "-m", "release"]);
-        run(&source, &["symbolic-ref", "HEAD", "refs/tags/release"]);
-        let expected = Command::new("git")
-            .arg("-C")
-            .arg(&source)
-            .args(["rev-parse", "--verify", "HEAD^{commit}"])
-            .output()
-            .unwrap();
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-
-        let destination = manager
-            .create(Create {
-                from: source,
-                name: Some("tag-head".into()),
-                into: None,
-            })
-            .unwrap();
-
-        assert_eq!(
-            fs::read_to_string(destination.join(".git/HEAD")).unwrap(),
-            format!("{}\n", String::from_utf8_lossy(&expected.stdout).trim())
-        );
-    }
-
-    #[test]
-    fn create_requires_an_initialized_workspace() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = manager(&temp);
-
-        assert!(matches!(
-            manager.create(Create {
-                from: source.clone(),
-                name: Some("unsafe".into()),
-                into: None,
-            }),
-            Err(Error::WorkspaceNotInitialized(_))
-        ));
-        assert!(!source.join(".rift").exists());
-    }
-
-    #[test]
-    fn unsafe_git_source_is_rejected_after_initialization() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        run(&source, &["init"]);
-        let mut manager = manager(&temp);
-        manager.init(&source).unwrap();
-        fs::write(source.join(".git/MERGE_HEAD"), "commit").unwrap();
-
-        assert!(matches!(
-            manager.create(Create {
-                from: source,
-                name: Some("unsafe".into()),
-                into: None,
-            }),
-            Err(Error::UnsafeGit(_))
-        ));
-    }
-
-    #[test]
-    fn unavailable_cow_does_not_create_a_child() {
-        let temp = TempDir::new().unwrap();
-        let source = source(&temp);
-        let mut manager = Manager::with_strategy(
-            temp.path().join("registry.sqlite"),
-            Box::new(FailureStrategy),
-        )
-        .unwrap();
-        manager.init(&source).unwrap();
-
-        assert!(matches!(
-            manager.create(Create {
-                from: source.clone(),
-                name: Some("failure".into()),
-                into: None,
-            }),
-            Err(Error::CowUnavailable(_))
-        ));
-        assert!(source.join(".rift").exists());
-        assert!(manager.list(&source).unwrap().is_empty());
-    }
-
-    fn run(path: &Path, args: &[&str]) {
-        assert!(
-            Command::new("git")
-                .arg("-C")
-                .arg(path)
-                .args(args)
-                .status()
-                .unwrap()
-                .success()
-        );
-    }
-}
+mod tests;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -66,8 +66,6 @@ pub struct Create {
     pub from: PathBuf,
     pub name: Option<String>,
     pub into: Option<PathBuf>,
-    pub copy_mode: CopyMode,
-    pub hook_mode: HookMode,
 }
 
 impl Create {
@@ -76,8 +74,6 @@ impl Create {
             from: from.into(),
             name: None,
             into: None,
-            copy_mode: CopyMode::default(),
-            hook_mode: HookMode::default(),
         }
     }
 
@@ -95,7 +91,15 @@ impl Create {
         self.into = into;
         self
     }
+}
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CreateOptions {
+    pub copy_mode: CopyMode,
+    pub hook_mode: HookMode,
+}
+
+impl CreateOptions {
     pub fn copy_mode(mut self, copy_mode: CopyMode) -> Self {
         self.copy_mode = copy_mode;
         self
@@ -179,6 +183,14 @@ impl Manager {
     }
 
     pub fn create(&mut self, input: Create) -> Result<PathBuf> {
+        self.create_with_options(input, CreateOptions::default())
+    }
+
+    pub fn create_with_options(
+        &mut self,
+        input: Create,
+        options: CreateOptions,
+    ) -> Result<PathBuf> {
         let requested = existing_directory(&input.from)?;
         let source = self.workspace_from(&requested)?;
         let from = source.path.clone();
@@ -202,14 +214,14 @@ impl Manager {
         if destination.exists() {
             return Err(Error::AlreadyExists(destination));
         }
-        let config = match input.hook_mode {
+        let config = match options.hook_mode {
             HookMode::Run => config::Config::load(&from)?,
             HookMode::Skip => config::Config::default(),
         };
 
         if let Err(error) = self
             .strategy
-            .copy_directory(&from, &destination, input.copy_mode)
+            .copy_directory(&from, &destination, options.copy_mode)
         {
             if destination.exists() {
                 let _ = self.strategy.remove_directory(&destination);

--- a/crates/core/src/strategy/apfs.rs
+++ b/crates/core/src/strategy/apfs.rs
@@ -1,36 +1,238 @@
 use super::Strategy;
-use crate::{Error, Result};
+use crate::{CopyMode, Error, Result, filter::CopyFilter};
+use std::fs;
 use std::path::Path;
+use walkdir::WalkDir;
 
 pub(super) struct ApfsStrategy;
 
 impl Strategy for ApfsStrategy {
-    fn copy_directory(&self, from: &Path, to: &Path) -> Result<()> {
-        use std::ffi::CString;
-        use std::os::unix::ffi::OsStrExt;
-
-        let source = CString::new(from.as_os_str().as_bytes())
-            .map_err(|_| Error::Path(format!("path contains a null byte: {}", from.display())))?;
-        let destination = CString::new(to.as_os_str().as_bytes())
-            .map_err(|_| Error::Path(format!("path contains a null byte: {}", to.display())))?;
-        // SAFETY: `source` and `destination` are null-terminated C strings
-        // built above, and both live for the duration of the call.
-        let result = unsafe { libc::clonefile(source.as_ptr(), destination.as_ptr(), 0) };
-        if result == 0 {
-            return Ok(());
+    fn copy_directory(&self, from: &Path, to: &Path, mode: CopyMode) -> Result<()> {
+        match mode {
+            CopyMode::All => clone_path_apfs(from, to),
+            CopyMode::Filtered => clone_filtered_directory_apfs(from, to),
         }
-        Err(Error::CowUnavailable(format!(
-            "failed to clone {}: {}",
-            from.display(),
-            std::io::Error::last_os_error()
-        )))
     }
+}
+
+fn clone_filtered_directory_apfs(from: &Path, to: &Path) -> Result<()> {
+    use std::collections::HashMap;
+    use std::os::unix::fs::MetadataExt;
+
+    let filter = CopyFilter;
+    let mut hard_links = HashMap::new();
+    let mut directories = Vec::new();
+    fs::create_dir(to)?;
+    for entry in WalkDir::new(from)
+        .min_depth(1)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|entry| {
+            entry
+                .path()
+                .strip_prefix(from)
+                .map_or(true, |path| !filter.excludes(path))
+        })
+    {
+        let entry = entry?;
+        let source = entry.path();
+        let destination = to.join(
+            source
+                .strip_prefix(from)
+                .map_err(|error| Error::Path(error.to_string()))?,
+        );
+        let metadata = fs::symlink_metadata(source)?;
+        let file_type = metadata.file_type();
+        if file_type.is_dir() {
+            fs::create_dir(&destination)?;
+            directories.push((source.to_path_buf(), destination));
+        } else if file_type.is_file() {
+            let key = (metadata.dev(), metadata.ino());
+            if metadata.nlink() > 1 {
+                if let Some(existing) = hard_links.get(&key) {
+                    fs::hard_link(existing, &destination)?;
+                } else {
+                    clone_path_apfs(source, &destination)?;
+                    hard_links.insert(key, destination.clone());
+                }
+            } else {
+                clone_path_apfs(source, &destination)?;
+            }
+            copy_metadata_apfs(source, &destination, MetadataTarget::FileOrDirectory)?;
+        } else if file_type.is_symlink() {
+            std::os::unix::fs::symlink(fs::read_link(source)?, &destination)?;
+            copy_metadata_apfs(source, &destination, MetadataTarget::Symlink)?;
+        } else {
+            return Err(Error::UnsupportedEntry(source.to_path_buf()));
+        }
+    }
+    for (source, destination) in directories.into_iter().rev() {
+        copy_metadata_apfs(&source, &destination, MetadataTarget::FileOrDirectory)?;
+    }
+    copy_metadata_apfs(from, to, MetadataTarget::FileOrDirectory)?;
+    Ok(())
+}
+
+fn clone_path_apfs(from: &Path, to: &Path) -> Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let source = CString::new(from.as_os_str().as_bytes())
+        .map_err(|_| Error::Path(format!("path contains a null byte: {}", from.display())))?;
+    let destination = CString::new(to.as_os_str().as_bytes())
+        .map_err(|_| Error::Path(format!("path contains a null byte: {}", to.display())))?;
+    // SAFETY: `source` and `destination` are null-terminated C strings
+    // built above, and both live for the duration of the call.
+    let result = unsafe { libc::clonefile(source.as_ptr(), destination.as_ptr(), 0) };
+    if result == 0 {
+        return Ok(());
+    }
+    Err(Error::CowUnavailable(format!(
+        "failed to clone {}: {}",
+        from.display(),
+        std::io::Error::last_os_error()
+    )))
+}
+
+#[derive(Clone, Copy)]
+enum MetadataTarget {
+    FileOrDirectory,
+    Symlink,
+}
+
+fn copy_metadata_apfs(from: &Path, to: &Path, target: MetadataTarget) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = fs::symlink_metadata(from)?;
+    let destination = c_path(to)?;
+    // SAFETY: `destination` is a valid null-terminated path, and uid/gid come
+    // from filesystem metadata for `from`.
+    if unsafe { libc::lchown(destination.as_ptr(), metadata.uid(), metadata.gid()) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    if matches!(target, MetadataTarget::FileOrDirectory) {
+        fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))?;
+    }
+    copy_xattrs_apfs(from, to)?;
+    let times = [
+        libc::timespec {
+            tv_sec: metadata.atime(),
+            tv_nsec: metadata.atime_nsec(),
+        },
+        libc::timespec {
+            tv_sec: metadata.mtime(),
+            tv_nsec: metadata.mtime_nsec(),
+        },
+    ];
+    // SAFETY: `destination` is a live C string and `times` contains exactly the
+    // two timestamps expected by `utimensat`.
+    if unsafe {
+        libc::utimensat(
+            libc::AT_FDCWD,
+            destination.as_ptr(),
+            times.as_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+fn copy_xattrs_apfs(from: &Path, to: &Path) -> Result<()> {
+    let from = c_path(from)?;
+    let to = c_path(to)?;
+    // SAFETY: `from` is a valid C path. A null buffer with size 0 asks the
+    // kernel for the required list size.
+    let size =
+        unsafe { libc::listxattr(from.as_ptr(), std::ptr::null_mut(), 0, libc::XATTR_NOFOLLOW) };
+    if size < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let mut names = vec![0_u8; size as usize];
+    // SAFETY: `names` was allocated with the size reported by the previous
+    // `listxattr` call, and its pointer is valid for writes of that length.
+    if size > 0
+        && unsafe {
+            libc::listxattr(
+                from.as_ptr(),
+                names.as_mut_ptr().cast(),
+                names.len(),
+                libc::XATTR_NOFOLLOW,
+            )
+        } < 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    for name in names
+        .split(|byte| *byte == 0)
+        .filter(|name| !name.is_empty())
+    {
+        let name = std::ffi::CString::new(name)
+            .map_err(|_| Error::Path("extended attribute name contains a null byte".into()))?;
+        // SAFETY: `from` and `name` are valid C strings. A null buffer with
+        // size 0 asks the kernel for this attribute's value length.
+        let size = unsafe {
+            libc::getxattr(
+                from.as_ptr(),
+                name.as_ptr(),
+                std::ptr::null_mut(),
+                0,
+                0,
+                libc::XATTR_NOFOLLOW,
+            )
+        };
+        if size < 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let mut value = vec![0_u8; size as usize];
+        // SAFETY: `value` was allocated with the exact size reported by
+        // `getxattr`, and the path and attribute name are valid C strings.
+        if size > 0
+            && unsafe {
+                libc::getxattr(
+                    from.as_ptr(),
+                    name.as_ptr(),
+                    value.as_mut_ptr().cast(),
+                    value.len(),
+                    0,
+                    libc::XATTR_NOFOLLOW,
+                )
+            } < 0
+        {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        // SAFETY: `to`, `name`, and `value` are valid for the duration of the
+        // call. `XATTR_NOFOLLOW` keeps symlink behavior consistent.
+        if unsafe {
+            libc::setxattr(
+                to.as_ptr(),
+                name.as_ptr(),
+                value.as_ptr().cast(),
+                value.len(),
+                0,
+                libc::XATTR_NOFOLLOW,
+            )
+        } != 0
+        {
+            return Err(std::io::Error::last_os_error().into());
+        }
+    }
+    Ok(())
+}
+
+fn c_path(path: &Path) -> Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| Error::Path(format!("path contains a null byte: {}", path.display())))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
     use tempfile::TempDir;
 
     #[test]
@@ -43,7 +245,9 @@ mod tests {
         fs::write(source.join("nested/file.txt"), "hello").unwrap();
         let strategy = ApfsStrategy;
 
-        strategy.copy_directory(&source, &destination).unwrap();
+        strategy
+            .copy_directory(&source, &destination, CopyMode::All)
+            .unwrap();
         assert_eq!(
             fs::read_to_string(destination.join("nested/file.txt")).unwrap(),
             "hello"
@@ -59,7 +263,72 @@ mod tests {
             let source = temp.path().join("source");
             let destination = temp.path().join("destination");
             fs::create_dir(&source).unwrap();
-            assert!(ApfsStrategy.copy_directory(&source, &destination).is_ok());
+            assert!(
+                ApfsStrategy
+                    .copy_directory(&source, &destination, CopyMode::All)
+                    .is_ok()
+            );
         }
+    }
+
+    #[test]
+    fn filtered_strategy_preserves_included_metadata_and_hard_links() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        let nested = source.join("nested");
+        fs::create_dir(&source).unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o750)).unwrap();
+        fs::create_dir(&nested).unwrap();
+        fs::set_permissions(&nested, fs::Permissions::from_mode(0o710)).unwrap();
+        let file = nested.join("file.txt");
+        fs::write(&file, "hello").unwrap();
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o640)).unwrap();
+        fs::hard_link(&file, nested.join("hard.txt")).unwrap();
+        std::os::unix::fs::symlink("file.txt", nested.join("link.txt")).unwrap();
+        fs::create_dir_all(source.join("node_modules/pkg")).unwrap();
+        fs::write(source.join("node_modules/pkg/index.js"), "module").unwrap();
+
+        ApfsStrategy
+            .copy_directory(&source, &destination, CopyMode::Filtered)
+            .unwrap();
+
+        assert!(!destination.join("node_modules").exists());
+        assert_eq!(
+            fs::read_to_string(destination.join("nested/file.txt")).unwrap(),
+            "hello"
+        );
+        assert_eq!(
+            fs::read_link(destination.join("nested/link.txt")).unwrap(),
+            Path::new("file.txt")
+        );
+        assert_eq!(
+            fs::metadata(destination.join("nested/file.txt"))
+                .unwrap()
+                .ino(),
+            fs::metadata(destination.join("nested/hard.txt"))
+                .unwrap()
+                .ino()
+        );
+        assert_eq!(
+            fs::metadata(destination.join("nested/file.txt"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o640
+        );
+        assert_eq!(
+            fs::metadata(destination.join("nested"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o710
+        );
+        assert_eq!(
+            fs::metadata(&destination).unwrap().permissions().mode() & 0o777,
+            0o750
+        );
     }
 }

--- a/crates/core/src/strategy/btrfs.rs
+++ b/crates/core/src/strategy/btrfs.rs
@@ -1,17 +1,19 @@
 use super::linux::{Filesystem, filesystem};
 #[cfg(test)]
 use super::reflink::c_path;
-use super::reflink::{MetadataTarget, copy_metadata_linux, import_directory_linux};
+use super::reflink::{
+    MetadataTarget, copy_metadata_linux, import_directory_linux, import_directory_linux_filtered,
+};
 use super::{Strategy, StrategyInit};
-use crate::{Error, InitProgress, Result};
+use crate::{CopyMode, Error, InitProgress, Result};
 use std::fs;
 use std::path::Path;
 
 pub(super) struct BtrfsStrategy;
 
 impl Strategy for BtrfsStrategy {
-    fn copy_directory(&self, from: &Path, to: &Path) -> Result<()> {
-        copy_directory_linux(from, to)
+    fn copy_directory(&self, from: &Path, to: &Path, mode: CopyMode) -> Result<()> {
+        copy_directory_linux(from, to, mode)
     }
 
     fn initialize_directory(
@@ -27,7 +29,7 @@ impl Strategy for BtrfsStrategy {
     }
 }
 
-fn copy_directory_linux(from: &Path, to: &Path) -> Result<()> {
+fn copy_directory_linux(from: &Path, to: &Path, mode: CopyMode) -> Result<()> {
     if !is_btrfs_filesystem(from)? {
         return Err(Error::CowUnavailable(format!(
             "Linux snapshot creation requires btrfs; {} is on another filesystem",
@@ -37,7 +39,17 @@ fn copy_directory_linux(from: &Path, to: &Path) -> Result<()> {
     if !is_btrfs_subvolume(from)? {
         return Err(Error::InitializationRequired(from.to_path_buf()));
     }
-    create_btrfs_snapshot(from, to)
+    match mode {
+        CopyMode::All => create_btrfs_snapshot(from, to),
+        CopyMode::Filtered => create_filtered_btrfs_subvolume(from, to),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn create_filtered_btrfs_subvolume(from: &Path, to: &Path) -> Result<()> {
+    create_btrfs_subvolume(to)?;
+    import_directory_linux_filtered(from, to, &mut |_| {})?;
+    copy_metadata_linux(from, to, MetadataTarget::FileOrDirectory)
 }
 
 #[cfg(target_os = "linux")]
@@ -373,7 +385,7 @@ mod linux_tests {
         create_btrfs_subvolume(&source).unwrap();
         fs::write(source.join("file.txt"), "hello").unwrap();
 
-        copy_directory_linux(&source, &snapshot).unwrap();
+        copy_directory_linux(&source, &snapshot, CopyMode::All).unwrap();
         assert_eq!(
             fs::read_to_string(snapshot.join("file.txt")).unwrap(),
             "hello"
@@ -394,7 +406,7 @@ mod linux_tests {
             Err(Error::CowUnavailable(_))
         ));
         assert!(matches!(
-            copy_directory_linux(temp.path(), &temp.path().join("snapshot")),
+            copy_directory_linux(temp.path(), &temp.path().join("snapshot"), CopyMode::All),
             Err(Error::CowUnavailable(_))
         ));
 

--- a/crates/core/src/strategy/linux.rs
+++ b/crates/core/src/strategy/linux.rs
@@ -1,15 +1,15 @@
 use super::{Strategy, StrategyInit, btrfs::BtrfsStrategy, reflink::LinuxReflinkStrategy};
-use crate::{Error, InitProgress, Result};
+use crate::{CopyMode, Error, InitProgress, Result};
 use std::fs;
 use std::path::Path;
 
 pub(super) struct LinuxStrategy;
 
 impl Strategy for LinuxStrategy {
-    fn copy_directory(&self, from: &Path, to: &Path) -> Result<()> {
+    fn copy_directory(&self, from: &Path, to: &Path, mode: CopyMode) -> Result<()> {
         match filesystem(from)? {
-            Filesystem::Btrfs => BtrfsStrategy.copy_directory(from, to),
-            Filesystem::Other => LinuxReflinkStrategy.copy_directory(from, to),
+            Filesystem::Btrfs => BtrfsStrategy.copy_directory(from, to, mode),
+            Filesystem::Other => LinuxReflinkStrategy.copy_directory(from, to, mode),
         }
     }
 

--- a/crates/core/src/strategy/mod.rs
+++ b/crates/core/src/strategy/mod.rs
@@ -1,6 +1,6 @@
+use crate::{CopyMode, InitProgress, Result};
 #[cfg(any(test, not(any(target_os = "linux", target_os = "macos"))))]
-use crate::Error;
-use crate::{InitProgress, Result};
+use crate::{Error, filter::CopyFilter};
 use std::fs;
 use std::path::Path;
 
@@ -14,7 +14,7 @@ mod linux;
 mod reflink;
 
 pub(crate) trait Strategy {
-    fn copy_directory(&self, from: &Path, to: &Path) -> Result<()>;
+    fn copy_directory(&self, from: &Path, to: &Path, mode: CopyMode) -> Result<()>;
 
     fn initialize_directory(
         &self,
@@ -53,7 +53,7 @@ struct UnsupportedStrategy;
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 impl Strategy for UnsupportedStrategy {
-    fn copy_directory(&self, _from: &Path, _to: &Path) -> Result<()> {
+    fn copy_directory(&self, _from: &Path, _to: &Path, _mode: CopyMode) -> Result<()> {
         Err(Error::CowUnavailable(
             "no copy-on-write strategy has been implemented for this platform".into(),
         ))
@@ -82,9 +82,21 @@ pub(crate) struct TestStrategy;
 
 #[cfg(test)]
 impl Strategy for TestStrategy {
-    fn copy_directory(&self, from: &Path, to: &Path) -> Result<()> {
+    fn copy_directory(&self, from: &Path, to: &Path, mode: CopyMode) -> Result<()> {
         fs::create_dir(to)?;
-        for entry in walkdir::WalkDir::new(from).min_depth(1).follow_links(false) {
+        let filter = CopyFilter;
+        for entry in walkdir::WalkDir::new(from)
+            .min_depth(1)
+            .follow_links(false)
+            .into_iter()
+            .filter_entry(|entry| {
+                mode == CopyMode::All
+                    || entry
+                        .path()
+                        .strip_prefix(from)
+                        .map_or(true, |path| !filter.excludes(path))
+            })
+        {
             let entry = entry?;
             let destination = to.join(
                 entry
@@ -111,7 +123,7 @@ pub(crate) struct FailureStrategy;
 
 #[cfg(test)]
 impl Strategy for FailureStrategy {
-    fn copy_directory(&self, _from: &Path, _to: &Path) -> Result<()> {
+    fn copy_directory(&self, _from: &Path, _to: &Path, _mode: CopyMode) -> Result<()> {
         Err(Error::CowUnavailable("test failure".into()))
     }
 }

--- a/crates/core/src/strategy/reflink.rs
+++ b/crates/core/src/strategy/reflink.rs
@@ -1,5 +1,5 @@
 use super::{Strategy, StrategyInit};
-use crate::{Error, InitProgress, Result};
+use crate::{CopyMode, Error, InitProgress, Result, filter::CopyFilter};
 use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
@@ -7,10 +7,13 @@ use walkdir::WalkDir;
 pub(super) struct LinuxReflinkStrategy;
 
 impl Strategy for LinuxReflinkStrategy {
-    fn copy_directory(&self, from: &Path, to: &Path) -> Result<()> {
+    fn copy_directory(&self, from: &Path, to: &Path, mode: CopyMode) -> Result<()> {
         let destination_parent = same_filesystem_parent(from, to)?;
         verify_reflinks_linux(destination_parent)?;
-        clone_directory_linux(from, to)
+        match mode {
+            CopyMode::All => clone_directory_linux(from, to),
+            CopyMode::Filtered => clone_directory_linux_filtered(from, to),
+        }
     }
 
     fn initialize_directory(
@@ -45,10 +48,33 @@ pub(super) fn clone_directory_linux(from: &Path, to: &Path) -> Result<()> {
     copy_metadata_linux(from, to, MetadataTarget::FileOrDirectory)
 }
 
+pub(super) fn clone_directory_linux_filtered(from: &Path, to: &Path) -> Result<()> {
+    fs::create_dir(to)?;
+    import_directory_linux_filtered(from, to, &mut |_| {})?;
+    copy_metadata_linux(from, to, MetadataTarget::FileOrDirectory)
+}
+
 pub(super) fn import_directory_linux(
     from: &Path,
     to: &Path,
     progress: &mut dyn FnMut(InitProgress),
+) -> Result<()> {
+    import_directory_linux_with_filter(from, to, progress, None)
+}
+
+pub(super) fn import_directory_linux_filtered(
+    from: &Path,
+    to: &Path,
+    progress: &mut dyn FnMut(InitProgress),
+) -> Result<()> {
+    import_directory_linux_with_filter(from, to, progress, Some(CopyFilter))
+}
+
+fn import_directory_linux_with_filter(
+    from: &Path,
+    to: &Path,
+    progress: &mut dyn FnMut(InitProgress),
+    filter: Option<CopyFilter>,
 ) -> Result<()> {
     use std::collections::HashMap;
     use std::os::unix::fs::MetadataExt;
@@ -59,6 +85,14 @@ pub(super) fn import_directory_linux(
         .min_depth(1)
         .follow_links(false)
         .into_iter()
+        .filter_entry(|entry| {
+            filter.map_or(true, |filter| {
+                entry
+                    .path()
+                    .strip_prefix(from)
+                    .map_or(true, |path| !filter.excludes(path))
+            })
+        })
         .zip(1..)
     {
         let entry = entry?;
@@ -318,7 +352,9 @@ mod tests {
         fs::hard_link(&file, nested.join("hard.txt")).unwrap();
         std::os::unix::fs::symlink("file.txt", nested.join("link.txt")).unwrap();
 
-        LinuxStrategy.copy_directory(&source, &destination).unwrap();
+        LinuxStrategy
+            .copy_directory(&source, &destination, CopyMode::All)
+            .unwrap();
 
         assert_eq!(
             fs::read_to_string(destination.join("nested/file.txt")).unwrap(),
@@ -365,7 +401,7 @@ mod tests {
         }
 
         assert!(matches!(
-            LinuxStrategy.copy_directory(&source, &other.path().join("destination")),
+            LinuxStrategy.copy_directory(&source, &other.path().join("destination"), CopyMode::All),
             Err(Error::CowUnavailable(_))
         ));
     }
@@ -380,7 +416,7 @@ mod tests {
         fs::create_dir(&source).unwrap();
 
         assert!(matches!(
-            LinuxStrategy.copy_directory(&source, &destination),
+            LinuxStrategy.copy_directory(&source, &destination, CopyMode::All),
             Err(Error::CowUnavailable(_))
         ));
         assert!(!destination.exists());

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -25,14 +25,8 @@ fn create_input(from: PathBuf, name: &str) -> Create {
     Create::new(from).named(name)
 }
 
-fn create_input_with_modes(
-    from: PathBuf,
-    name: &str,
-    copy_mode: CopyMode,
-    hook_mode: HookMode,
-) -> Create {
-    Create::new(from)
-        .named(name)
+fn create_options(copy_mode: CopyMode, hook_mode: HookMode) -> CreateOptions {
+    CreateOptions::default()
         .copy_mode(copy_mode)
         .hook_mode(hook_mode)
 }
@@ -177,12 +171,10 @@ fn create_copy_all_preserves_regenerable_artifacts() {
     manager.init(&source).unwrap();
 
     let child = manager
-        .create(create_input_with_modes(
-            source.clone(),
-            "copy-all",
-            CopyMode::All,
-            HookMode::Run,
-        ))
+        .create_with_options(
+            create_input(source.clone(), "copy-all"),
+            create_options(CopyMode::All, HookMode::Run),
+        )
         .unwrap();
 
     assert_eq!(
@@ -265,12 +257,10 @@ fn hook_skip_ignores_invalid_config() {
     manager.init(&source).unwrap();
 
     let child = manager
-        .create(create_input_with_modes(
-            source,
-            "skip-hooks",
-            CopyMode::Filtered,
-            HookMode::Skip,
-        ))
+        .create_with_options(
+            create_input(source, "skip-hooks"),
+            create_options(CopyMode::Filtered, HookMode::Skip),
+        )
         .unwrap();
 
     assert!(child.join(".rift.toml").exists());

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -1,0 +1,886 @@
+use super::*;
+use crate::strategy::{FailureStrategy, Strategy, TestStrategy};
+use std::cell::Cell;
+use std::process::Command;
+use std::rc::Rc;
+use tempfile::TempDir;
+use ulid::Ulid;
+
+fn manager(temp: &TempDir) -> Manager {
+    Manager::with_strategy(temp.path().join("registry.sqlite"), Box::new(TestStrategy)).unwrap()
+}
+
+fn source(temp: &TempDir) -> PathBuf {
+    let source = temp.path().join("app");
+    fs::create_dir(&source).unwrap();
+    fs::write(source.join("file.txt"), "hello").unwrap();
+    fs::canonicalize(source).unwrap()
+}
+
+fn marker_id(path: &Path) -> RiftId {
+    marker::read(path).unwrap().unwrap()
+}
+
+fn create_input(from: PathBuf, name: &str) -> Create {
+    Create::new(from).named(name)
+}
+
+fn create_input_with_modes(
+    from: PathBuf,
+    name: &str,
+    copy_mode: CopyMode,
+    hook_mode: HookMode,
+) -> Create {
+    Create::new(from)
+        .named(name)
+        .copy_mode(copy_mode)
+        .hook_mode(hook_mode)
+}
+
+fn child_path(source: &Path, name: &str) -> PathBuf {
+    source.parent().unwrap().join(".rifts/app").join(name)
+}
+
+#[test]
+fn create_tracks_parentage_and_default_storage() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+
+    let parent = source.parent().unwrap();
+    assert_eq!(first, parent.join(".rifts/app/first"));
+    assert_eq!(second, parent.join(".rifts/app/second"));
+    assert_ne!(
+        fs::read_to_string(source.join(".rift")).unwrap(),
+        fs::read_to_string(first.join(".rift")).unwrap()
+    );
+    assert_eq!(manager.list(&source).unwrap(), vec![first.clone()]);
+    assert_eq!(manager.ancestors(&second).unwrap(), vec![first, source]);
+}
+
+#[test]
+fn init_registers_a_root_workspace_without_creating_a_child() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+
+    assert_eq!(manager.init(&source).unwrap(), InitOutcome::Registered);
+    assert!(source.join(".rift").exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+    assert_eq!(
+        manager.init(&source).unwrap(),
+        InitOutcome::AlreadyInitialized
+    );
+}
+
+#[test]
+fn init_reports_structured_registration_progress_when_requested() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    let mut progress = Vec::new();
+
+    manager
+        .init_with_progress(&source, |event| progress.push(event))
+        .unwrap();
+
+    assert_eq!(progress, vec![InitProgress::RegisteringWorkspace]);
+}
+
+#[test]
+fn create_supports_custom_storage_and_rejects_invalid_destinations() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let custom = temp.path().join("custom");
+    let child = manager
+        .create(
+            Create::new(source.clone())
+                .named("custom")
+                .with_storage(Some(custom.clone())),
+        )
+        .unwrap();
+    assert_eq!(child, fs::canonicalize(&custom).unwrap().join("custom"));
+    assert!(matches!(
+        manager.create(
+            Create::new(source.clone())
+                .named("custom")
+                .with_storage(Some(custom))
+        ),
+        Err(Error::AlreadyExists(_))
+    ));
+    assert!(matches!(
+        manager.create(Create::new(source.clone()).named("..")),
+        Err(Error::Path(_))
+    ));
+    assert!(matches!(
+        manager.create(
+            Create::new(source.clone())
+                .named("inside")
+                .with_storage(Some(source.join("nested")))
+        ),
+        Err(Error::InsideSource(_))
+    ));
+    assert!(matches!(
+        manager.create(Create::new(source.join("file.txt")).named("file")),
+        Err(Error::Path(_))
+    ));
+}
+
+#[test]
+fn create_filters_regenerable_artifacts_by_default() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    fs::create_dir_all(source.join("node_modules/pkg")).unwrap();
+    fs::write(source.join("node_modules/pkg/index.js"), "module").unwrap();
+    fs::create_dir_all(source.join("target/debug")).unwrap();
+    fs::write(source.join("target/debug/app"), "binary").unwrap();
+    fs::create_dir_all(source.join(".yarn/cache")).unwrap();
+    fs::write(source.join(".yarn/cache/pkg.zip"), "cache").unwrap();
+    fs::write(source.join("package.json"), "{}").unwrap();
+    fs::write(source.join("Cargo.lock"), "lock").unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let child = manager
+        .create(create_input(source.clone(), "filtered"))
+        .unwrap();
+
+    assert!(!child.join("node_modules").exists());
+    assert!(!child.join("target").exists());
+    assert!(!child.join(".yarn/cache").exists());
+    assert_eq!(
+        fs::read_to_string(child.join("package.json")).unwrap(),
+        "{}"
+    );
+    assert_eq!(
+        fs::read_to_string(child.join("Cargo.lock")).unwrap(),
+        "lock"
+    );
+}
+
+#[test]
+fn create_copy_all_preserves_regenerable_artifacts() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    fs::create_dir_all(source.join("node_modules/pkg")).unwrap();
+    fs::write(source.join("node_modules/pkg/index.js"), "module").unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let child = manager
+        .create(create_input_with_modes(
+            source.clone(),
+            "copy-all",
+            CopyMode::All,
+            HookMode::Run,
+        ))
+        .unwrap();
+
+    assert_eq!(
+        fs::read_to_string(child.join("node_modules/pkg/index.js")).unwrap(),
+        "module"
+    );
+}
+
+#[test]
+fn create_runs_postclone_hooks_in_destination_order() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    fs::write(
+        source.join(".rift.toml"),
+        r#"
+version = 1
+
+[[hooks.postclone]]
+run = "echo first >> hook.log"
+
+[[hooks.postclone]]
+run = "echo second >> hook.log"
+"#,
+    )
+    .unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let child = manager.create(create_input(source, "hooks")).unwrap();
+    let log = fs::read_to_string(child.join("hook.log")).unwrap();
+
+    assert!(log.find("first").unwrap() < log.find("second").unwrap());
+}
+
+#[test]
+fn postclone_failure_leaves_registered_workspace() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    fs::write(
+        source.join(".rift.toml"),
+        r#"
+version = 1
+
+[[hooks.postclone]]
+run = "echo before >> hook.log"
+
+[[hooks.postclone]]
+run = "exit 7"
+
+[[hooks.postclone]]
+run = "echo after >> hook.log"
+"#,
+    )
+    .unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let expected = child_path(&source, "hook-failure");
+
+    let error = manager
+        .create(create_input(source.clone(), "hook-failure"))
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::HookFailed { path, .. } if path == expected
+    ));
+    assert!(expected.exists());
+    assert_eq!(manager.list(&source).unwrap(), vec![expected.clone()]);
+    let log = fs::read_to_string(expected.join("hook.log")).unwrap();
+    assert!(log.contains("before"));
+    assert!(!log.contains("after"));
+}
+
+#[test]
+fn hook_skip_ignores_invalid_config() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    fs::write(source.join(".rift.toml"), "version = 2\n").unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let child = manager
+        .create(create_input_with_modes(
+            source,
+            "skip-hooks",
+            CopyMode::Filtered,
+            HookMode::Skip,
+        ))
+        .unwrap();
+
+    assert!(child.join(".rift.toml").exists());
+}
+
+#[test]
+fn invalid_hook_config_fails_before_copying() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    fs::write(source.join(".rift.toml"), "version = 2\n").unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let expected = child_path(&source, "invalid-config");
+
+    let error = manager
+        .create(create_input(source, "invalid-config"))
+        .unwrap_err();
+
+    assert!(matches!(error, Error::InvalidConfig { .. }));
+    assert!(!expected.exists());
+}
+
+#[test]
+fn corrupt_and_unknown_markers_are_rejected() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let nested = source.join("nested");
+    fs::create_dir(&nested).unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    fs::write(source.join(".rift"), "unknown\n").unwrap();
+    assert!(matches!(
+        manager.list(&nested),
+        Err(Error::UnknownMarker(_))
+    ));
+
+    let id = manager.registry.record_at(&source).unwrap().unwrap().id;
+    fs::write(source.join(".rift"), format!("{id}\n")).unwrap();
+    let other = temp.path().join("other");
+    fs::create_dir(&other).unwrap();
+    fs::write(other.join(".rift"), format!("{id}\n")).unwrap();
+    assert!(matches!(
+        manager.list(&other),
+        Err(Error::MarkerMismatch(_))
+    ));
+}
+
+#[test]
+fn removal_rejects_marker_mismatch_and_existing_trash_target() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let child = manager
+        .create(Create::new(source.clone()).named("child"))
+        .unwrap();
+    let id = marker_id(&child);
+    fs::write(child.join(".rift"), "wrong\n").unwrap();
+    assert!(matches!(
+        manager.remove(&child),
+        Err(Error::UnknownMarker(_))
+    ));
+    fs::write(
+        child.join(".rift"),
+        fs::read_to_string(source.join(".rift")).unwrap(),
+    )
+    .unwrap();
+    assert!(matches!(
+        manager.remove(&child),
+        Err(Error::MarkerMismatch(_))
+    ));
+    fs::write(child.join(".rift"), format!("{id}\n")).unwrap();
+    let trash = trash_path(&id, &child).unwrap();
+    fs::create_dir_all(&trash).unwrap();
+    assert!(matches!(
+        manager.remove(&child),
+        Err(Error::AlreadyExists(_))
+    ));
+}
+
+#[test]
+fn gc_forgets_a_trashed_path_already_removed_on_disk() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let child = manager.create(Create::new(source).named("child")).unwrap();
+    let id = marker_id(&child);
+    let trash = trash_path(&id, &child).unwrap();
+    manager.remove(&child).unwrap();
+    fs::remove_dir_all(&trash).unwrap();
+
+    assert_eq!(manager.gc().unwrap(), vec![trash]);
+}
+
+#[test]
+fn operations_use_the_nearest_ancestor_marker() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let nested = source.join("packages/app");
+    fs::create_dir_all(&nested).unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let child = manager.create(Create::new(nested).named("nested")).unwrap();
+    fs::create_dir(child.join("deep")).unwrap();
+
+    assert_eq!(
+        manager.list(source.join("packages")).unwrap(),
+        vec![child.clone()]
+    );
+    assert_eq!(manager.ancestors(child.join("deep")).unwrap(), vec![source]);
+}
+
+#[test]
+fn operations_without_a_marker_explain_how_to_initialize() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let nested = source.join("nested");
+    fs::create_dir(&nested).unwrap();
+    let manager = manager(&temp);
+
+    assert!(matches!(
+        manager.list(&nested),
+        Err(Error::WorkspaceNotInitialized(path)) if path == nested
+    ));
+}
+
+#[test]
+fn init_restores_a_deleted_marker_for_an_existing_workspace() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let nested = source.join("nested");
+    fs::create_dir(&nested).unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let id = fs::read_to_string(source.join(".rift")).unwrap();
+    fs::remove_file(source.join(".rift")).unwrap();
+
+    assert!(matches!(
+        manager.list(&nested),
+        Err(Error::MissingMarker(path)) if path == source
+    ));
+
+    manager.init(&source).unwrap();
+    assert_eq!(fs::read_to_string(source.join(".rift")).unwrap(), id);
+    assert!(manager.list(&nested).unwrap().is_empty());
+}
+
+struct InitializingStrategy {
+    initialized: Rc<Cell<bool>>,
+}
+
+impl Strategy for InitializingStrategy {
+    fn copy_directory(&self, _from: &Path, _to: &Path, _mode: CopyMode) -> Result<()> {
+        unreachable!()
+    }
+
+    fn initialize_directory(
+        &self,
+        _path: &Path,
+        _progress: &mut dyn FnMut(InitProgress),
+    ) -> Result<StrategyInit> {
+        self.initialized.set(true);
+        Ok(StrategyInit::Converted)
+    }
+}
+
+#[test]
+fn init_continues_initialization_after_restoring_a_marker() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut registered = manager(&temp);
+    registered.init(&source).unwrap();
+    fs::remove_file(source.join(".rift")).unwrap();
+    drop(registered);
+    let initialized = Rc::new(Cell::new(false));
+    let mut manager = Manager::with_strategy(
+        temp.path().join("registry.sqlite"),
+        Box::new(InitializingStrategy {
+            initialized: initialized.clone(),
+        }),
+    )
+    .unwrap();
+
+    assert_eq!(manager.init(&source).unwrap(), InitOutcome::Converted);
+    assert!(initialized.get());
+    assert!(source.join(".rift").exists());
+}
+
+#[test]
+fn init_registers_exactly_the_requested_directory() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let nested = source.join("nested");
+    fs::create_dir(&nested).unwrap();
+    run(&source, &["init"]);
+    let mut manager = manager(&temp);
+
+    manager.init(&nested).unwrap();
+    assert!(!source.join(".rift").exists());
+    assert!(nested.join(".rift").exists());
+}
+
+#[test]
+fn create_generates_readable_names_independent_of_ulid_identity() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let destination = manager.create(Create::new(source)).unwrap();
+    let name = destination.file_name().unwrap().to_str().unwrap();
+    let parts = name.split('-').collect::<Vec<_>>();
+    let id = fs::read_to_string(destination.join(".rift")).unwrap();
+    let id = id.trim();
+
+    assert_eq!(parts.len(), 2);
+    assert!(
+        parts[0]
+            .chars()
+            .all(|character| character.is_ascii_lowercase())
+    );
+    assert!(
+        parts[1]
+            .chars()
+            .all(|character| character.is_ascii_lowercase())
+    );
+    assert!(Ulid::from_string(id).is_ok());
+    assert_ne!(name, id);
+}
+
+#[test]
+fn remove_trashes_a_full_subtree_and_gc_deletes_it() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+
+    let first_id = marker_id(&first);
+    let first_trash = trash_path(&first_id, &first).unwrap();
+    let second_id = marker_id(&second);
+    let second_trash = trash_path(&second_id, &second).unwrap();
+
+    manager.remove(&first).unwrap();
+
+    assert!(!first.exists());
+    assert!(!second.exists());
+    assert!(first_trash.exists());
+    assert!(second_trash.exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+    let deleted = manager.gc().unwrap();
+    assert!(deleted.contains(&second_trash));
+    assert!(deleted.contains(&first_trash));
+    assert_eq!(deleted.len(), 2);
+    assert!(!first_trash.exists());
+    assert!(!second_trash.exists());
+}
+
+#[test]
+fn remove_on_a_registered_root_unregisters_it_and_trashes_descendants() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+    let first_id = marker_id(&first);
+    let first_trash = trash_path(&first_id, &first).unwrap();
+    let second_id = marker_id(&second);
+    let second_trash = trash_path(&second_id, &second).unwrap();
+
+    manager.remove(&source).unwrap();
+
+    assert!(source.exists());
+    assert!(!source.join(".rift").exists());
+    assert!(!first.exists());
+    assert!(!second.exists());
+    assert!(first_trash.exists());
+    assert!(second_trash.exists());
+    assert!(matches!(
+        manager.list(&source),
+        Err(Error::WorkspaceNotInitialized(_))
+    ));
+    let deleted = manager.gc().unwrap();
+    assert!(deleted.contains(&first_trash));
+    assert!(deleted.contains(&second_trash));
+}
+
+#[test]
+fn remove_on_a_registered_root_tolerates_missing_descendants() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    fs::remove_dir_all(&first).unwrap();
+
+    manager.remove(&source).unwrap();
+
+    assert!(source.exists());
+    assert!(!source.join(".rift").exists());
+    assert!(matches!(
+        manager.list(&source),
+        Err(Error::WorkspaceNotInitialized(_))
+    ));
+}
+
+#[test]
+fn remove_all_deletes_descendants_and_preserves_the_selected_workspace() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+    let sibling = manager
+        .create(Create::new(source.clone()).named("sibling"))
+        .unwrap();
+    let first_id = marker_id(&first);
+    let first_trash = trash_path(&first_id, &first).unwrap();
+
+    let removed = manager.remove_all(&source).unwrap();
+    assert_eq!(removed[0], second);
+    assert!(removed.contains(&first));
+    assert!(removed.contains(&sibling));
+    assert_eq!(removed.len(), 3);
+    assert!(source.exists());
+    assert!(!first.exists());
+    assert!(first_trash.exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[test]
+fn remove_all_preserves_a_nested_selected_rift() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager.create(Create::new(source).named("first")).unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+
+    assert_eq!(manager.remove_all(&first).unwrap(), vec![second]);
+    assert!(first.exists());
+    assert!(manager.list(&first).unwrap().is_empty());
+}
+
+#[test]
+fn remove_refuses_a_subtree_with_an_unlinked_move() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+    fs::rename(&second, temp.path().join("moved")).unwrap();
+
+    assert!(matches!(manager.remove(&first), Err(Error::MissingRift(_))));
+    assert!(first.exists());
+}
+
+#[test]
+fn gc_removes_trashed_entries() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+    let first_id = marker_id(&first);
+    let second_id = marker_id(&second);
+    let first_trash = trash_path(&first_id, &first).unwrap();
+    let second_trash = trash_path(&second_id, &second).unwrap();
+    manager.remove(&first).unwrap();
+
+    let deleted = manager.gc().unwrap();
+    assert!(deleted.contains(&second_trash));
+    assert!(deleted.contains(&first_trash));
+    assert_eq!(deleted.len(), 2);
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[test]
+fn gc_has_no_effect_on_active_rifts() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+    assert!(manager.gc().unwrap().is_empty());
+    assert_eq!(manager.ancestors(&second).unwrap(), vec![first, source]);
+}
+
+#[test]
+fn gc_prunes_active_entries_deleted_outside_rift() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+    fs::remove_dir_all(&first).unwrap();
+    fs::remove_dir_all(&second).unwrap();
+
+    let removed = manager.gc().unwrap();
+    assert!(removed.contains(&first));
+    assert!(removed.contains(&second));
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[test]
+fn gc_preserves_missing_active_parent_with_an_existing_descendant() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let first = manager
+        .create(Create::new(source.clone()).named("first"))
+        .unwrap();
+    let second = manager
+        .create(Create::new(first.clone()).named("second"))
+        .unwrap();
+    fs::remove_dir_all(&first).unwrap();
+
+    assert!(manager.gc().unwrap().is_empty());
+    assert_eq!(manager.list(&source).unwrap(), vec![first]);
+    assert_eq!(
+        manager.ancestors(&second).unwrap(),
+        vec![source.parent().unwrap().join(".rifts/app/first"), source]
+    );
+}
+
+#[test]
+fn git_copy_detaches_head_and_preserves_dirty_state() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    run(&source, &["init"]);
+    run(&source, &["config", "user.email", "test@example.com"]);
+    run(&source, &["config", "user.name", "Test"]);
+    run(&source, &["add", "file.txt"]);
+    run(&source, &["commit", "-m", "initial"]);
+    fs::write(source.join("file.txt"), "changed").unwrap();
+    run(&source, &["add", "file.txt"]);
+    fs::write(source.join("untracked.txt"), "new").unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let destination = manager
+        .create(Create::new(source.clone()).named("git"))
+        .unwrap();
+
+    let source_commit = Command::new("git")
+        .arg("-C")
+        .arg(&source)
+        .args(["rev-parse", "--verify", "HEAD^{commit}"])
+        .output()
+        .unwrap();
+    assert!(
+        !Command::new("git")
+            .arg("-C")
+            .arg(&destination)
+            .args(["symbolic-ref", "-q", "HEAD"])
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert_eq!(
+        fs::read_to_string(destination.join(".git/HEAD")).unwrap(),
+        format!(
+            "{}\n",
+            String::from_utf8_lossy(&source_commit.stdout).trim()
+        )
+    );
+    let staged = Command::new("git")
+        .arg("-C")
+        .arg(&destination)
+        .args(["diff", "--cached", "--name-only"])
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&staged.stdout).contains("file.txt"));
+    assert!(destination.join("untracked.txt").exists());
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(&destination)
+        .args(["status", "--porcelain", "--", ".rift"])
+        .output()
+        .unwrap();
+    assert!(status.stdout.is_empty());
+}
+
+#[test]
+fn git_copy_peels_symbolic_tag_heads_to_commits() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    run(&source, &["init"]);
+    run(&source, &["config", "user.email", "test@example.com"]);
+    run(&source, &["config", "user.name", "Test"]);
+    run(&source, &["add", "file.txt"]);
+    run(&source, &["commit", "-m", "initial"]);
+    run(&source, &["tag", "-a", "release", "-m", "release"]);
+    run(&source, &["symbolic-ref", "HEAD", "refs/tags/release"]);
+    let expected = Command::new("git")
+        .arg("-C")
+        .arg(&source)
+        .args(["rev-parse", "--verify", "HEAD^{commit}"])
+        .output()
+        .unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let destination = manager
+        .create(Create::new(source).named("tag-head"))
+        .unwrap();
+
+    assert_eq!(
+        fs::read_to_string(destination.join(".git/HEAD")).unwrap(),
+        format!("{}\n", String::from_utf8_lossy(&expected.stdout).trim())
+    );
+}
+
+#[test]
+fn create_requires_an_initialized_workspace() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+
+    assert!(matches!(
+        manager.create(Create::new(source.clone()).named("unsafe")),
+        Err(Error::WorkspaceNotInitialized(_))
+    ));
+    assert!(!source.join(".rift").exists());
+}
+
+#[test]
+fn unsafe_git_source_is_rejected_after_initialization() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    run(&source, &["init"]);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    fs::write(source.join(".git/MERGE_HEAD"), "commit").unwrap();
+
+    assert!(matches!(
+        manager.create(Create::new(source).named("unsafe")),
+        Err(Error::UnsafeGit(_))
+    ));
+}
+
+#[test]
+fn unavailable_cow_does_not_create_a_child() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = Manager::with_strategy(
+        temp.path().join("registry.sqlite"),
+        Box::new(FailureStrategy),
+    )
+    .unwrap();
+    manager.init(&source).unwrap();
+
+    assert!(matches!(
+        manager.create(Create::new(source.clone()).named("failure")),
+        Err(Error::CowUnavailable(_))
+    ));
+    assert!(source.join(".rift").exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+fn run(path: &Path, args: &[&str]) {
+    assert!(
+        Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(args)
+            .status()
+            .unwrap()
+            .success()
+    );
+}

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -1,4 +1,4 @@
-use rift::{CopyMode, Create, Error, HookMode, Manager};
+use rift::{CopyMode, Create, CreateOptions, Error, HookMode, Manager};
 use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString, c_char};
 use std::path::PathBuf;
@@ -121,10 +121,9 @@ fn execute(input: &str) -> Result<Value, Failure> {
             copy_all,
             hooks,
         } => manager
-            .create(
-                Create::new(from)
-                    .with_name(name)
-                    .with_storage(into)
+            .create_with_options(
+                Create::new(from).with_name(name).with_storage(into),
+                CreateOptions::default()
                     .copy_mode(if copy_all.unwrap_or(false) {
                         CopyMode::All
                     } else {

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -1,4 +1,4 @@
-use rift::{Create, Error, Manager};
+use rift::{CopyMode, Create, Error, HookMode, Manager};
 use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString, c_char};
 use std::path::PathBuf;
@@ -20,6 +20,9 @@ enum Command {
         from: PathBuf,
         name: Option<String>,
         into: Option<PathBuf>,
+        #[serde(rename = "copyAll")]
+        copy_all: Option<bool>,
+        hooks: Option<bool>,
     },
     Remove {
         at: PathBuf,
@@ -88,6 +91,8 @@ impl From<Error> for Failure {
             Error::AlreadyExists(path) => ("already_exists", Some(path.clone())),
             Error::MissingRift(path) => ("missing_rift", Some(path.clone())),
             Error::InsideSource(path) => ("inside_source", Some(path.clone())),
+            Error::InvalidConfig { path, .. } => ("invalid_config", Some(path.clone())),
+            Error::HookFailed { path, .. } => ("hook_failed", Some(path.clone())),
         };
         Self {
             code,
@@ -109,8 +114,28 @@ fn execute(input: &str) -> Result<Value, Failure> {
             .init(at)
             .map(|_| Value::Empty(()))
             .map_err(Failure::from),
-        Command::Create { from, name, into } => manager
-            .create(Create { from, name, into })
+        Command::Create {
+            from,
+            name,
+            into,
+            copy_all,
+            hooks,
+        } => manager
+            .create(
+                Create::new(from)
+                    .with_name(name)
+                    .with_storage(into)
+                    .copy_mode(if copy_all.unwrap_or(false) {
+                        CopyMode::All
+                    } else {
+                        CopyMode::Filtered
+                    })
+                    .hook_mode(if hooks.unwrap_or(true) {
+                        HookMode::Run
+                    } else {
+                        HookMode::Skip
+                    }),
+            )
             .map(|path| Value::Path(Some(path)))
             .map_err(Failure::from),
         Command::Remove { at, all } => {
@@ -220,6 +245,56 @@ mod tests {
             "workspace is not initialized: /tmp/app"
         );
         assert_eq!(response["error"]["path"], "/tmp/app");
+    }
+
+    #[test]
+    fn new_create_options_are_accepted_by_the_protocol() {
+        let request = serde_json::from_str::<Request>(
+            r#"{
+                "command": "create",
+                "from": "/tmp/app",
+                "name": "child",
+                "into": null,
+                "copyAll": true,
+                "hooks": false
+            }"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            request.command,
+            Command::Create {
+                copy_all: Some(true),
+                hooks: Some(false),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn hook_and_config_errors_are_exposed_with_codes_and_paths() {
+        let config = serde_json::to_value(Response::Error {
+            error: Error::InvalidConfig {
+                path: PathBuf::from("/tmp/app/.rift.toml"),
+                message: "bad".into(),
+            }
+            .into(),
+        })
+        .unwrap();
+        let hook = serde_json::to_value(Response::Error {
+            error: Error::HookFailed {
+                path: PathBuf::from("/tmp/app"),
+                command: "exit 1".into(),
+                message: "exited with 1".into(),
+            }
+            .into(),
+        })
+        .unwrap();
+
+        assert_eq!(config["error"]["code"], "invalid_config");
+        assert_eq!(config["error"]["path"], "/tmp/app/.rift.toml");
+        assert_eq!(hook["error"]["code"], "hook_failed");
+        assert_eq!(hook["error"]["path"], "/tmp/app");
     }
 
     #[test]

--- a/npm/rift-snapshot/bun/index.js
+++ b/npm/rift-snapshot/bun/index.js
@@ -51,8 +51,8 @@ export function init({ at = process.cwd(), database } = {}) {
   return call({ command: "init", at, database })
 }
 
-export function create({ from = process.cwd(), name, into, database } = {}) {
-  return call({ command: "create", from, name, into, database })
+export function create({ from = process.cwd(), name, into, copyAll, hooks, database } = {}) {
+  return call({ command: "create", from, name, into, copyAll, hooks, database })
 }
 
 export function remove({ at = process.cwd(), all = false, database } = {}) {

--- a/npm/rift-snapshot/index.d.ts
+++ b/npm/rift-snapshot/index.d.ts
@@ -10,6 +10,8 @@ export interface CreateOptions extends Options {
   from?: string
   name?: string
   into?: string
+  copyAll?: boolean
+  hooks?: boolean
 }
 
 export interface RemoveOptions extends AtOptions {
@@ -37,6 +39,8 @@ export type RiftErrorCode =
   | "already_exists"
   | "missing_rift"
   | "inside_source"
+  | "invalid_config"
+  | "hook_failed"
   | "invalid_request"
   | "panic"
   | "serialization"

--- a/npm/rift-snapshot/node/index.js
+++ b/npm/rift-snapshot/node/index.js
@@ -44,8 +44,8 @@ export function init({ at = process.cwd(), database } = {}) {
   return call({ command: "init", at, database })
 }
 
-export function create({ from = process.cwd(), name, into, database } = {}) {
-  return call({ command: "create", from, name, into, database })
+export function create({ from = process.cwd(), name, into, copyAll, hooks, database } = {}) {
+  return call({ command: "create", from, name, into, copyAll, hooks, database })
 }
 
 export function remove({ at = process.cwd(), all = false, database } = {}) {

--- a/specs.md
+++ b/specs.md
@@ -33,6 +33,8 @@ create(input: {
   from: AbsolutePath
   name?: string
   into?: AbsolutePath
+  copyAll?: boolean
+  hooks?: boolean
 }): AbsolutePath
 ```
 
@@ -41,9 +43,25 @@ Default behavior:
 - Source is `from`.
 - `name` defaults to a random adjective-noun directory name independent of the rift ULID.
 - `into` defaults to the managed rift directory.
-- Copy the whole workspace, including dirty, staged, untracked, and ignored files.
+- Copy the workspace while excluding known heavyweight regenerable dependency, build, and cache artifacts.
+- Preserve manifests, lockfiles, dirty files, staged files, untracked files, and ignored files that are not part of the built-in excluded artifact set.
+- `copyAll` opts into exact copying, including dependency and build artifacts.
+- `hooks` defaults to true and runs `.rift.toml` postclone hooks after copy, Git preparation, and registry insertion. `hooks: false` skips config loading and hook execution.
 - Detach `HEAD` in the new workspace.
 - Return the path of the new workspace.
+
+Default excluded artifacts are matched at any depth and include `node_modules`, `.pnpm-store`, `.yarn/cache`, `.yarn/unplugged`, `.yarn/install-state.gz`, `.yarn/build-state.yml`, `target`, `.venv`, `venv`, `.tox`, `.nox`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.next`, `.nuxt`, `.svelte-kit`, `.turbo`, `.vite`, `.parcel-cache`, `.cache`, `dist`, `build`, and `coverage`.
+
+`.rift.toml` supports one v1 hook shape:
+
+```toml
+version = 1
+
+[[hooks.postclone]]
+run = "pnpm install --frozen-lockfile"
+```
+
+Postclone hooks run sequentially in the destination workspace with inherited stdio and environment plus `RIFT_SOURCE`, `RIFT_DESTINATION`, `RIFT_ID`, and `RIFT_PARENT_ID`. The first failing command stops later hooks. The created workspace remains registered and on disk, and the create operation reports a hook failure with the destination path.
 
 On btrfs, `from` must already be a subvolume. If it is an ordinary directory, fail and instruct the user to run `rift init` first. On other reflink-capable Linux filesystems, clone the directory tree with native per-file reflinks.
 
@@ -163,7 +181,7 @@ Git support is an integration for directories that contain repositories; it does
 When registering or creating from a Git repository:
 
 - Add `/.rift` to `.git/info/exclude` so the identity marker does not appear in local Git status.
-- Copy the directory with its staged, unstaged, untracked, ignored, and cached state intact.
+- Preserve staged, unstaged, untracked, ignored, and cached state for copied paths.
 - If `HEAD` resolves to a commit, detach `HEAD` in the created destination at that same commit.
 - Preserve the copied index and working tree state while detaching.
 - If the repository has no commits yet, leave its unborn branch state unchanged because there is no commit to detach to.
@@ -181,9 +199,9 @@ The tool does not create branches, commit changes, or otherwise replace normal G
 Copying is implemented behind a `Strategy` interface so platform-specific copy-on-write backends can be added independently. Each strategy owns initialization, snapshot creation, and removal behavior for its filesystem.
 
 - The `BtrfsStrategy` production strategy on Linux uses writable btrfs subvolume snapshots.
-- The `BtrfsStrategy` performs a native per-file reflink import only when `init` converts an existing ordinary workspace into a subvolume; it does not spawn an external copy command and may report import progress. Its `create` never performs file-by-file cloning.
+- The `BtrfsStrategy` performs native per-file reflink imports when `init` converts an existing ordinary workspace into a subvolume and when filtered `create` materializes only included paths. Exact `create` uses writable btrfs snapshots.
 - The `LinuxReflinkStrategy` production strategy on Linux verifies native reflink support during `init` and uses native per-file reflinks during `create` without spawning an external copy command. XFS uses this path, as do other Linux filesystems when their `FICLONE` support succeeds.
-- The `ApfsStrategy` production strategy on macOS uses APFS `clonefile` directory cloning.
+- The `ApfsStrategy` production strategy on macOS uses APFS `clonefile` directory cloning for exact copies and per-entry cloning for filtered copies.
 - If no implemented copy-on-write strategy succeeds, `create` fails.
 - Full byte copying is not implemented as a fallback.
 - Future strategies may add Windows copy-on-write support without changing the API.


### PR DESCRIPTION
## summary

- add default filtered workspace copies for regenerable dependency and build artifacts
- add `.rift.toml` `[[hooks.postclone]]` support across cli and ffi create APIs
- preserve metadata for filtered copy paths and split core create tests out of `lib.rs`

## validation

- `cargo fmt --all`
- `cargo test --workspace --locked`
