### PR TITLE
test: add filesystem cli e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Prepare filesystem and run tests
         run: |
           bash scripts/ci/linux-fs.sh "${{ matrix.filesystem }}" -- \
-            env ${{ matrix.required_env }}=1 cargo test --package rift --locked
+            env ${{ matrix.required_env }}=1 cargo test --package rift --package rift-cli --locked
 
   apfs-test:
     name: APFS integration tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ version = "0.0.9"
 dependencies = [
  "clap",
  "rift",
+ "rusqlite",
  "tempfile",
  "thiserror",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,4 +14,5 @@ rift = { path = "../core" }
 thiserror.workspace = true
 
 [dev-dependencies]
+rusqlite.workspace = true
 tempfile.workspace = true

--- a/crates/cli/tests/filesystem_e2e.rs
+++ b/crates/cli/tests/filesystem_e2e.rs
@@ -1,0 +1,166 @@
+#[cfg(target_os = "linux")]
+mod support;
+
+#[cfg(target_os = "linux")]
+use std::ffi::{OsStr, OsString};
+#[cfg(target_os = "linux")]
+use std::fs;
+#[cfg(target_os = "linux")]
+use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use support::filesystem::{
+    CliFixture, assert_different_filesystems, assert_registry_empty,
+    supported_linux_filesystem_tests_required, unsupported_linux_filesystem_tests_required,
+};
+
+#[cfg(target_os = "linux")]
+#[test]
+fn supported_filesystem_cli_round_trip() {
+    if !supported_linux_filesystem_tests_required() {
+        return;
+    }
+    let fixture = CliFixture::current_filesystem(".rift-cli-supported-");
+    let source = fixture.root().join("source");
+    create_workspace(&source);
+
+    let init = fixture.success(
+        fixture.root(),
+        [os("init"), os(source.as_os_str()), os("--here")],
+    );
+    assert!(init.stdout.is_empty());
+    assert!(source.join(".rift").exists());
+
+    let child = fixture
+        .success(&source, ["create", "--name", "child"])
+        .single_stdout_path();
+    assert_eq!(child, fixture.root().join(".rifts/source/child"));
+    assert_workspace_copy(&child);
+
+    let custom_parent = fixture.root().join("custom-storage");
+    let custom = fixture
+        .success(
+            &source,
+            [
+                os("create"),
+                os("--name"),
+                os("custom"),
+                os("--into"),
+                os(custom_parent.as_os_str()),
+            ],
+        )
+        .single_stdout_path();
+    assert_eq!(custom, custom_parent.join("custom"));
+    assert_workspace_copy(&custom);
+
+    assert_paths_unordered(
+        fixture.success(&source, ["list"]).stdout_paths(),
+        &[child.clone(), custom.clone()],
+    );
+    assert_eq!(
+        fixture
+            .success(&source, [os("ancestors"), os(custom.as_os_str())])
+            .stdout_paths(),
+        vec![source.clone()]
+    );
+
+    let external = tempfile::TempDir::new().unwrap();
+    assert_different_filesystems(&source, external.path());
+    let external_parent = external.path().join("external-storage");
+    let failed = fixture.failure(
+        &source,
+        [
+            os("create"),
+            os("--name"),
+            os("external"),
+            os("--into"),
+            os(external_parent.as_os_str()),
+        ],
+    );
+    assert!(failed.stderr.contains("copy-on-write cloning unavailable"));
+    assert!(!external_parent.join("external").exists());
+
+    let remove = fixture.success(&source, [os("remove"), os(child.as_os_str())]);
+    assert!(remove.stdout.is_empty());
+    assert!(!child.exists());
+    assert_eq!(
+        fixture.success(&source, ["list"]).stdout_paths(),
+        vec![custom.clone()]
+    );
+
+    let removed = fixture.success(&source, ["gc"]).stdout_paths();
+    assert_eq!(removed.len(), 1);
+    assert!(removed[0].starts_with(fixture.root().join(".rifts/source/.trash")));
+    assert!(!removed[0].exists());
+    assert!(!fixture.default_database().exists());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn unsupported_filesystem_cli_fails_closed() {
+    if !unsupported_linux_filesystem_tests_required() {
+        return;
+    }
+    let fixture = CliFixture::current_filesystem(".rift-cli-unsupported-");
+    let source = fixture.root().join("source");
+    create_workspace(&source);
+
+    let init = fixture.failure(
+        fixture.root(),
+        [os("init"), os(source.as_os_str()), os("--here")],
+    );
+    assert!(init.stdout.is_empty());
+    assert!(init.stderr.contains("copy-on-write cloning unavailable"));
+    assert!(!source.join(".rift").exists());
+    assert!(!fixture.root().join(".rifts").exists());
+    assert_no_reflink_probe_files(&source);
+    assert_registry_empty(fixture.database());
+
+    let create = fixture.failure(&source, ["create", "--name", "child"]);
+    assert!(create.stderr.contains("no initialized workspace found"));
+    assert!(!fixture.root().join(".rifts/source/child").exists());
+    assert!(!fixture.default_database().exists());
+    assert_registry_empty(fixture.database());
+}
+
+#[cfg(target_os = "linux")]
+fn create_workspace(source: &Path) {
+    fs::create_dir_all(source.join("nested")).unwrap();
+    fs::write(source.join("nested/file.txt"), "hello from cli e2e").unwrap();
+    fs::write(source.join("untracked.txt"), "kept").unwrap();
+}
+
+#[cfg(target_os = "linux")]
+fn assert_workspace_copy(path: &Path) {
+    assert_eq!(
+        fs::read_to_string(path.join("nested/file.txt")).unwrap(),
+        "hello from cli e2e"
+    );
+    assert_eq!(
+        fs::read_to_string(path.join("untracked.txt")).unwrap(),
+        "kept"
+    );
+    assert!(path.join(".rift").exists());
+}
+
+#[cfg(target_os = "linux")]
+fn assert_no_reflink_probe_files(path: &Path) {
+    assert!(
+        fs::read_dir(path)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .all(|name| !name.to_string_lossy().starts_with(".rift-reflink-probe"))
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn assert_paths_unordered(mut actual: Vec<PathBuf>, expected: &[PathBuf]) {
+    let mut expected = expected.to_vec();
+    actual.sort();
+    expected.sort();
+    assert_eq!(actual, expected);
+}
+
+#[cfg(target_os = "linux")]
+fn os(arg: impl AsRef<OsStr>) -> OsString {
+    arg.as_ref().to_os_string()
+}

--- a/crates/cli/tests/support/filesystem.rs
+++ b/crates/cli/tests/support/filesystem.rs
@@ -1,0 +1,170 @@
+use rusqlite::Connection;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::{Builder, TempDir};
+
+#[derive(Debug)]
+pub struct CommandOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl CommandOutput {
+    pub fn stdout_paths(&self) -> Vec<PathBuf> {
+        self.stdout.lines().map(PathBuf::from).collect()
+    }
+
+    pub fn single_stdout_path(&self) -> PathBuf {
+        let paths = self.stdout_paths();
+        assert_eq!(paths.len(), 1, "expected one stdout path, got {paths:?}");
+        paths.into_iter().next().unwrap()
+    }
+}
+
+pub struct CliFixture {
+    temp: TempDir,
+    home: PathBuf,
+    xdg_data_home: PathBuf,
+    database: PathBuf,
+    binary: PathBuf,
+}
+
+impl CliFixture {
+    pub fn current_filesystem(prefix: &str) -> Self {
+        let temp = Builder::new()
+            .prefix(prefix)
+            .tempdir_in(std::env::current_dir().unwrap())
+            .unwrap();
+        let home = temp.path().join("home");
+        let xdg_data_home = temp.path().join("xdg-data");
+        let database = temp.path().join("registry.sqlite");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&xdg_data_home).unwrap();
+
+        Self {
+            temp,
+            home,
+            xdg_data_home,
+            database,
+            binary: PathBuf::from(env!("CARGO_BIN_EXE_rift")),
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        self.temp.path()
+    }
+
+    pub fn database(&self) -> &Path {
+        &self.database
+    }
+
+    pub fn default_database(&self) -> PathBuf {
+        self.xdg_data_home.join("rift/rift.sqlite")
+    }
+
+    pub fn success<I, S>(&self, cwd: &Path, args: I) -> CommandOutput
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let (args, output) = self.run(cwd, args);
+        assert!(
+            output.status.success(),
+            "expected success for `{}`\nstdout:\n{}\nstderr:\n{}",
+            command_line(&args),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        command_output(output)
+    }
+
+    pub fn failure<I, S>(&self, cwd: &Path, args: I) -> CommandOutput
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let (args, output) = self.run(cwd, args);
+        assert!(
+            !output.status.success(),
+            "expected failure for `{}`\nstdout:\n{}\nstderr:\n{}",
+            command_line(&args),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        command_output(output)
+    }
+
+    fn run<I, S>(&self, cwd: &Path, args: I) -> (Vec<OsString>, Output)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let args = args
+            .into_iter()
+            .map(|arg| arg.as_ref().to_os_string())
+            .collect::<Vec<_>>();
+        let output = Command::new(&self.binary)
+            .arg("--database")
+            .arg(&self.database)
+            .args(&args)
+            .current_dir(cwd)
+            .env("HOME", &self.home)
+            .env("XDG_DATA_HOME", &self.xdg_data_home)
+            .output()
+            .unwrap();
+        (args, output)
+    }
+}
+
+pub fn supported_linux_filesystem_tests_required() -> bool {
+    ["RIFT_REQUIRE_BTRFS_TESTS", "RIFT_REQUIRE_REFLINK_TESTS"]
+        .into_iter()
+        .any(|name| std::env::var_os(name).is_some())
+}
+
+pub fn unsupported_linux_filesystem_tests_required() -> bool {
+    std::env::var_os("RIFT_REQUIRE_UNSUPPORTED_LINUX_TESTS").is_some()
+}
+
+pub fn assert_registry_empty(path: &Path) {
+    let database = Connection::open(path).unwrap();
+    assert_eq!(row_count(&database, "rift"), 0);
+    assert_eq!(row_count(&database, "trash"), 0);
+}
+
+pub fn assert_different_filesystems(left: &Path, right: &Path) {
+    use std::os::unix::fs::MetadataExt;
+
+    assert_ne!(
+        std::fs::metadata(left).unwrap().dev(),
+        std::fs::metadata(right).unwrap().dev(),
+        "expected {} and {} to be on different filesystems",
+        left.display(),
+        right.display()
+    );
+}
+
+fn row_count(database: &Connection, table: &str) -> i64 {
+    let sql = match table {
+        "rift" => "SELECT COUNT(*) FROM rift",
+        "trash" => "SELECT COUNT(*) FROM trash",
+        _ => unreachable!("unexpected table: {table}"),
+    };
+    database.query_row(sql, [], |row| row.get(0)).unwrap()
+}
+
+fn command_output(output: Output) -> CommandOutput {
+    CommandOutput {
+        stdout: String::from_utf8(output.stdout).unwrap(),
+        stderr: String::from_utf8(output.stderr).unwrap(),
+    }
+}
+
+fn command_line(args: &[OsString]) -> String {
+    std::iter::once(OsStr::new("rift"))
+        .chain(args.iter().map(OsString::as_os_str))
+        .map(|arg| arg.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/crates/cli/tests/support/mod.rs
+++ b/crates/cli/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod filesystem;


### PR DESCRIPTION
## summary
- add linux-gated CLI e2e tests that execute the real `rift` binary with isolated HOME, XDG data, and registry paths
- cover supported filesystem flows for init, create, list, ancestors, same-filesystem `--into`, cross-device `--into` failure, remove, and gc
- cover unsupported filesystem init/create failure-closed behavior with marker, registry, probe, and child cleanup assertions
- run `rift-cli` alongside `rift` in the linux filesystem matrix

## validation
- `cargo fmt --all`
- `git diff --check`
- `$HOME/.cargo/bin/cargo test --workspace --locked`
- `$HOME/.cargo/bin/cargo test --package rift --package rift-cli --locked`

## note
- linux filesystem e2e assertions are gated by the same matrix env vars, so the mounted filesystem behavior is exercised in ubuntu ci
