### PR TITLE
test: broaden failure cleanup coverage

### DIFF
--- a/crates/core/src/linux_filesystem_tests.rs
+++ b/crates/core/src/linux_filesystem_tests.rs
@@ -95,6 +95,7 @@ fn production_unsupported_linux_filesystem_rejects_management() {
     assert!(!source.join(".rift").exists());
     assert!(!temp.path().join(".rifts").exists());
     assert_reflink_probe_cleaned_up(&source);
+    assert_registry_empty(&manager);
 
     assert!(matches!(
         manager.create(Create {
@@ -109,6 +110,40 @@ fn production_unsupported_linux_filesystem_rejects_management() {
         manager.list(&source),
         Err(Error::WorkspaceNotInitialized(_))
     ));
+    assert_registry_empty(&manager);
+}
+
+#[test]
+fn production_supported_linux_filesystem_cleans_partial_copy_failure() {
+    if !requires_supported_linux_filesystem_tests() {
+        return;
+    }
+    let temp = current_filesystem_temp();
+    let source = rich_git_workspace(temp.path());
+    let registry = temp.path().join("registry.sqlite");
+    let mut manager = Manager::open(&registry).unwrap();
+    manager.init(&source).unwrap();
+    assert_only_registered_path(&manager, &source);
+
+    let fifo = source.join("fifo");
+    make_fifo(&fifo);
+    let storage = temp.path().join(".rifts/source");
+    let expected = storage.join("unsupported-entry");
+
+    let error = manager
+        .create(Create {
+            from: source.clone(),
+            name: Some("unsupported-entry".into()),
+            into: None,
+        })
+        .unwrap_err();
+
+    assert!(matches!(error, Error::UnsupportedEntry(path) if path == fifo));
+    assert!(source.join(".rift").exists());
+    assert!(!expected.exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+    assert_only_registered_path(&manager, &source);
+    assert_reflink_probe_cleaned_up(&storage);
 }
 
 fn requires_supported_linux_filesystem_tests() -> bool {
@@ -239,6 +274,25 @@ fn assert_reflink_probe_cleaned_up(path: &Path) {
     );
 }
 
+fn assert_registry_empty(manager: &Manager) {
+    assert!(manager.registry.active_paths().unwrap().is_empty());
+    assert!(manager.registry.trashed_paths().unwrap().is_empty());
+}
+
+fn assert_only_registered_path(manager: &Manager, path: &Path) {
+    assert_eq!(
+        manager
+            .registry
+            .active_paths()
+            .unwrap()
+            .into_iter()
+            .map(|record| record.path)
+            .collect::<Vec<_>>(),
+        vec![path.to_path_buf()]
+    );
+    assert!(manager.registry.trashed_paths().unwrap().is_empty());
+}
+
 fn assert_btrfs_subvolume_if_required(path: &Path) {
     if std::env::var_os("RIFT_REQUIRE_BTRFS_TESTS").is_some() {
         assert!(
@@ -268,6 +322,16 @@ fn assert_copy_diverges_after_mutation(source: &Path, child: &Path) {
 
 fn same_device(left: &Path, right: &Path) -> bool {
     fs::metadata(left).unwrap().dev() == fs::metadata(right).unwrap().dev()
+}
+
+fn make_fifo(path: &Path) {
+    let path = c_path(path);
+    assert_eq!(
+        // SAFETY: `path` is a valid C path and the mode is a standard FIFO
+        // permission bitmask for this test fixture.
+        unsafe { libc::mkfifo(path.as_ptr(), 0o600) },
+        0
+    );
 }
 
 fn git(path: &Path, args: &[&str]) {

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::strategy::{FailureStrategy, Strategy, TestStrategy};
 use std::cell::Cell;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 use std::rc::Rc;
 use tempfile::TempDir;
@@ -830,18 +832,175 @@ fn create_requires_an_initialized_workspace() {
 }
 
 #[test]
-fn unsafe_git_source_is_rejected_after_initialization() {
+fn unsafe_git_states_are_rejected_after_initialization() {
     let temp = TempDir::new().unwrap();
     let source = source(&temp);
     run(&source, &["init"]);
     let mut manager = manager(&temp);
     manager.init(&source).unwrap();
-    fs::write(source.join(".git/MERGE_HEAD"), "commit").unwrap();
 
-    assert!(matches!(
-        manager.create(Create::new(source).named("unsafe")),
-        Err(Error::UnsafeGit(_))
-    ));
+    for state in [
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "BISECT_LOG",
+        "rebase-merge",
+        "rebase-apply",
+        "index.lock",
+        "HEAD.lock",
+    ] {
+        let marker = source.join(".git").join(state);
+        if state.starts_with("rebase-") {
+            fs::create_dir(&marker).unwrap();
+        } else {
+            fs::write(&marker, "commit").unwrap();
+        }
+        let name = format!("unsafe-{state}");
+        let expected = child_path(&source, &name);
+
+        let error = manager
+            .create(Create::new(source.clone()).named(name))
+            .unwrap_err();
+
+        assert!(matches!(error, Error::UnsafeGit(message) if message.contains(state)));
+        assert!(!expected.exists());
+        assert!(manager.list(&source).unwrap().is_empty());
+        if marker.is_dir() {
+            fs::remove_dir(&marker).unwrap();
+        } else {
+            fs::remove_file(&marker).unwrap();
+        }
+    }
+}
+
+#[test]
+fn linked_git_worktree_source_is_rejected_after_initialization() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    run(&source, &["init"]);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    fs::remove_dir_all(source.join(".git")).unwrap();
+    fs::write(source.join(".git"), "gitdir: ../linked/.git").unwrap();
+
+    let error = manager
+        .create(Create::new(source.clone()).named("linked-worktree"))
+        .unwrap_err();
+
+    assert!(matches!(error, Error::UnsafeGit(message) if message.contains("linked")));
+    assert!(!child_path(&source, "linked-worktree").exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+struct PartialFailureStrategy;
+
+impl Strategy for PartialFailureStrategy {
+    fn copy_directory(&self, _from: &Path, to: &Path, _mode: CopyMode) -> Result<()> {
+        fs::create_dir(to)?;
+        fs::write(to.join("copied-before-failure.txt"), "partial")?;
+        fs::create_dir(to.join("nested"))?;
+        fs::write(to.join("nested/file.txt"), "partial")?;
+        Err(Error::CowUnavailable("partial failure".into()))
+    }
+}
+
+#[test]
+fn partial_copy_failure_removes_child_and_registry_row() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = Manager::with_strategy(
+        temp.path().join("registry.sqlite"),
+        Box::new(PartialFailureStrategy),
+    )
+    .unwrap();
+    manager.init(&source).unwrap();
+    let expected = child_path(&source, "partial");
+
+    let error = manager
+        .create(Create::new(source.clone()).named("partial"))
+        .unwrap_err();
+
+    assert!(matches!(error, Error::CowUnavailable(message) if message == "partial failure"));
+    assert!(source.join(".rift").exists());
+    assert!(!expected.exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_source_file_failure_removes_child_and_registry_row() {
+    if running_as_root() {
+        return;
+    }
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let secret = source.join("secret.txt");
+    fs::write(&secret, "secret").unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    fs::set_permissions(&secret, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let result = manager.create(Create::new(source.clone()).named("unreadable-file"));
+    fs::set_permissions(&secret, fs::Permissions::from_mode(0o600)).unwrap();
+    let error = result.unwrap_err();
+
+    assert!(matches!(error, Error::Io(_)));
+    assert!(source.join(".rift").exists());
+    assert!(!child_path(&source, "unreadable-file").exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_source_directory_failure_removes_child_and_registry_row() {
+    if running_as_root() {
+        return;
+    }
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let secret = source.join("secret");
+    fs::create_dir(&secret).unwrap();
+    fs::write(secret.join("file.txt"), "secret").unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    fs::set_permissions(&secret, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let result = manager.create(Create::new(source.clone()).named("unreadable-directory"));
+    fs::set_permissions(&secret, fs::Permissions::from_mode(0o700)).unwrap();
+    let error = result.unwrap_err();
+
+    assert!(matches!(error, Error::Walk(_) | Error::Io(_)));
+    assert!(source.join(".rift").exists());
+    assert!(!child_path(&source, "unreadable-directory").exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn unwritable_destination_parent_failure_leaves_no_child_or_registry_row() {
+    if running_as_root() {
+        return;
+    }
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let parent = temp.path().join("readonly");
+    fs::create_dir(&parent).unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    fs::set_permissions(&parent, fs::Permissions::from_mode(0o500)).unwrap();
+
+    let result = manager.create(
+        Create::new(source.clone())
+            .named("blocked")
+            .with_storage(Some(parent.clone())),
+    );
+    fs::set_permissions(&parent, fs::Permissions::from_mode(0o700)).unwrap();
+    let error = result.unwrap_err();
+
+    assert!(matches!(error, Error::Io(_)));
+    assert!(source.join(".rift").exists());
+    assert!(!parent.join("blocked").exists());
+    assert!(manager.list(&source).unwrap().is_empty());
 }
 
 #[test]
@@ -861,6 +1020,12 @@ fn unavailable_cow_does_not_create_a_child() {
     ));
     assert!(source.join(".rift").exists());
     assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[cfg(unix)]
+fn running_as_root() -> bool {
+    // SAFETY: geteuid has no preconditions and only reads the process identity.
+    unsafe { libc::geteuid() == 0 }
 }
 
 fn run(path: &Path, args: &[&str]) {


### PR DESCRIPTION
- cover unsafe Git state rejection across merge, rebase, cherry-pick, revert, bisect, lock, and linked-worktree markers
- verify partial copy, unreadable source, and unwritable destination failures leave no child rows or child directories
- extend Linux filesystem matrix tests to assert supported partial-copy cleanup and unsupported registry cleanliness

checks:
- `cargo fmt --check`
- `cargo test --workspace --locked`
- `cargo check --target x86_64-unknown-linux-gnu --tests --package rift --locked` blocked locally because this macOS host is missing `x86_64-linux-gnu-gcc` for `libsqlite3-sys`/`libz-sys`