### PR TITLE
feat: add postremove hooks

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Default)]
 pub(crate) struct Config {
     postcreate: Vec<Postcreate>,
+    postremove: Vec<Postremove>,
 }
 
 impl Config {
@@ -20,6 +21,10 @@ impl Config {
     pub(crate) fn postcreate(&self) -> &[Postcreate] {
         &self.postcreate
     }
+
+    pub(crate) fn postremove(&self) -> &[Postremove] {
+        &self.postremove
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -28,6 +33,17 @@ pub(crate) struct Postcreate {
 }
 
 impl Postcreate {
+    pub(crate) fn run(&self) -> &str {
+        &self.run
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Postremove {
+    run: String,
+}
+
+impl Postremove {
     pub(crate) fn run(&self) -> &str {
         &self.run
     }
@@ -46,11 +62,19 @@ struct RawConfig {
 struct RawHooks {
     #[serde(default)]
     postcreate: Vec<RawPostcreate>,
+    #[serde(default)]
+    postremove: Vec<RawPostremove>,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawPostcreate {
+    run: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPostremove {
     run: String,
 }
 
@@ -63,7 +87,8 @@ fn parse(path: &Path, contents: &str) -> Result<Config> {
             format!("unsupported config version {}", raw.version),
         ));
     }
-    raw.hooks
+    let postcreate = raw
+        .hooks
         .postcreate
         .into_iter()
         .map(|step| {
@@ -74,8 +99,24 @@ fn parse(path: &Path, contents: &str) -> Result<Config> {
                 Ok(Postcreate { run })
             }
         })
-        .collect::<Result<Vec<_>>>()
-        .map(|postcreate| Config { postcreate })
+        .collect::<Result<Vec<_>>>()?;
+    let postremove = raw
+        .hooks
+        .postremove
+        .into_iter()
+        .map(|step| {
+            let run = step.run.trim().to_owned();
+            if run.is_empty() {
+                Err(invalid_config(path, "postremove run cannot be empty"))
+            } else {
+                Ok(Postremove { run })
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Config {
+        postcreate,
+        postremove,
+    })
 }
 
 fn invalid_config(path: &Path, message: impl Into<String>) -> Error {
@@ -146,5 +187,84 @@ shell = "sh"
             ),
             Err(Error::InvalidConfig { .. })
         ));
+    }
+
+    #[test]
+    fn parses_ordered_postremove_steps() {
+        let config = parse(
+            Path::new(".rift.toml"),
+            r#"
+version = 1
+
+[[hooks.postremove]]
+run = "echo one"
+
+[[hooks.postremove]]
+run = "echo two"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config
+                .postremove()
+                .iter()
+                .map(Postremove::run)
+                .collect::<Vec<_>>(),
+            vec!["echo one", "echo two"]
+        );
+    }
+
+    #[test]
+    fn rejects_empty_postremove_steps() {
+        assert!(matches!(
+            parse(
+                Path::new(".rift.toml"),
+                r#"
+version = 1
+
+[[hooks.postremove]]
+run = " "
+"#,
+            ),
+            Err(Error::InvalidConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_fields_on_postremove() {
+        assert!(matches!(
+            parse(
+                Path::new(".rift.toml"),
+                r#"
+version = 1
+
+[[hooks.postremove]]
+run = "echo ok"
+shell = "sh"
+"#,
+            ),
+            Err(Error::InvalidConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn parses_both_hook_types_together() {
+        let config = parse(
+            Path::new(".rift.toml"),
+            r#"
+version = 1
+
+[[hooks.postcreate]]
+run = "npm install"
+
+[[hooks.postremove]]
+run = "docker compose down"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.postcreate().len(), 1);
+        assert_eq!(config.postremove().len(), 1);
     }
 }

--- a/crates/core/src/hook.rs
+++ b/crates/core/src/hook.rs
@@ -1,4 +1,4 @@
-use crate::config::Postcreate;
+use crate::config::{Postcreate, Postremove};
 use crate::id::RiftId;
 use crate::{Error, Result};
 use std::path::Path;
@@ -14,6 +14,19 @@ pub(crate) fn run_postcreate(
     steps
         .iter()
         .map(Postcreate::run)
+        .try_for_each(|command| run_step(command, source, destination, id, parent_id))
+}
+
+pub(crate) fn run_postremove(
+    steps: &[Postremove],
+    source: &Path,
+    destination: &Path,
+    id: &RiftId,
+    parent_id: &RiftId,
+) -> Result<()> {
+    steps
+        .iter()
+        .map(Postremove::run)
         .try_for_each(|command| run_step(command, source, destination, id, parent_id))
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,7 +59,7 @@ pub enum Error {
     InsideSource(PathBuf),
     #[error("invalid rift config at {path}: {message}")]
     InvalidConfig { path: PathBuf, message: String },
-    #[error("postcreate hook failed at {path}: `{command}` {message}")]
+    #[error("hook failed at {path}: `{command}` {message}")]
     HookFailed {
         path: PathBuf,
         command: String,
@@ -311,6 +311,19 @@ impl Manager {
             return self.unregister_root(&record);
         }
         marker::verify(&record.path, &record.id)?;
+        let config = config::Config::load(&record.path)?;
+        let parent_id = record.parent_id.as_ref().unwrap();
+        let parent = self
+            .registry
+            .record_id(parent_id)?
+            .ok_or_else(|| Error::NotManaged(record.path.clone()))?;
+        hook::run_postremove(
+            config.postremove(),
+            &parent.path,
+            &record.path,
+            &record.id,
+            parent_id,
+        )?;
         let rows = self
             .registry
             .subtree(&record.id, SubtreeScope::IncludingRoot)?;
@@ -321,6 +334,11 @@ impl Manager {
     pub fn remove_all(&mut self, at: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
         let record = self.workspace_at(at)?;
         marker::verify(&record.path, &record.id)?;
+        // Postremove hooks are intentionally not run for bulk descendant removal —
+        // each descendant may have its own hooks, and running them during a
+        // recursive tear-down would require loading config per-child and handling
+        // partial failures across the subtree. Callers that need hook behaviour
+        // should remove descendants individually with remove() first.
         let rows = self
             .registry
             .subtree(&record.id, SubtreeScope::DescendantsOnly)?;

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -1039,3 +1039,68 @@ fn run(path: &Path, args: &[&str]) {
             .success()
     );
 }
+
+#[test]
+fn postremove_runs_hooks_in_order_before_directory_is_moved() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let child = manager.create(create_input(source.clone(), "postremove-order")).unwrap();
+    // Write .rift.toml into the child (postremove config lives in the rift being removed)
+    fs::write(
+        child.join(".rift.toml"),
+        r#"
+version = 1
+
+[[hooks.postremove]]
+run = "echo first >> ../hook.log"
+
+[[hooks.postremove]]
+run = "echo second >> ../hook.log"
+"#,
+    )
+    .unwrap();
+    let log = child.parent().unwrap().join("hook.log");
+
+    manager.remove(&child).unwrap();
+
+    let contents = fs::read_to_string(&log).unwrap();
+    assert!(contents.find("first").unwrap() < contents.find("second").unwrap());
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[test]
+fn postremove_failure_aborts_removal() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let child = manager.create(create_input(source.clone(), "postremove-failure")).unwrap();
+    fs::write(
+        child.join(".rift.toml"),
+        r#"
+version = 1
+
+[[hooks.postremove]]
+run = "echo before >> ../hook.log"
+
+[[hooks.postremove]]
+run = "exit 7"
+
+[[hooks.postremove]]
+run = "echo after >> ../hook.log"
+"#,
+    )
+    .unwrap();
+    let log = child.parent().unwrap().join("hook.log");
+
+    let error = manager.remove(&child).unwrap_err();
+
+    assert!(matches!(error, Error::HookFailed { path, .. } if path == child));
+    assert!(child.exists());
+    assert_eq!(manager.list(&source).unwrap(), vec![child.clone()]);
+    let contents = fs::read_to_string(&log).unwrap();
+    assert!(contents.contains("before"));
+    assert!(!contents.contains("after"));
+}


### PR DESCRIPTION
Hello all, I'm using the create hook to run `docker-compose up` with `COMPOSE_PROJECT_NAME` set to the rift name, so that each rift has their own infra.

But bc there's no post removal hook, these containers/networks/volumes dangle after the rift is deleted, which is annoying to delete manually.

So my goal with this PR is to introduce a [[hooks.postremove]] in .rift.toml, mirroring the existing postcreate hook shape. 

- config: Postremove struct, RawPostremove, parse, accessor, tests
- hook: run_postremove (parallel to run_postcreate)
- lib: remove() loads config, resolves parent, runs postremove hooks before trash_rows; missing parent record is an error not a silent skip
- lib: HookFailed message generalised from "postcreate" to "hook"
- lib: remove_all documents why postremove hooks are intentionally skipped
- tests: postremove order and failure-aborts-removal integration tests