### PR TITLE
Fix macOS permission denied error 13

### DIFF
--- a/crates/core/src/strategy/apfs.rs
+++ b/crates/core/src/strategy/apfs.rs
@@ -283,7 +283,50 @@ mod tests {
         fs::set_permissions(&nested, fs::Permissions::from_mode(0o710)).unwrap();
         let file = nested.join("file.txt");
         fs::write(&file, "hello").unwrap();
-        fs::set_permissions(&file, fs::Permissions::from_mode(0o640)).unwrap();
+        let file_path = c_path(&file).unwrap();
+        let attribute = std::ffi::CString::new("com.rift.test").unwrap();
+        let attribute_value = b"preserved";
+        // SAFETY: the path and attribute are valid C strings, and the value
+        // pointer is valid for `attribute_value.len()` bytes.
+        assert_eq!(
+            unsafe {
+                libc::setxattr(
+                    file_path.as_ptr(),
+                    attribute.as_ptr(),
+                    attribute_value.as_ptr().cast(),
+                    attribute_value.len(),
+                    0,
+                    0,
+                )
+            },
+            0
+        );
+        // The read-only mode makes a redundant xattr rewrite fail with EACCES,
+        // while the special bits verify clonefile's mode exception is repaired.
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o6555)).unwrap();
+        assert_eq!(
+            fs::metadata(&file).unwrap().permissions().mode() & 0o7777,
+            0o6555
+        );
+        // Confirm this fixture rejects the same setxattr operation the old
+        // metadata replay performed.
+        assert_eq!(
+            unsafe {
+                libc::setxattr(
+                    file_path.as_ptr(),
+                    attribute.as_ptr(),
+                    attribute_value.as_ptr().cast(),
+                    attribute_value.len(),
+                    0,
+                    libc::XATTR_NOFOLLOW,
+                )
+            },
+            -1
+        );
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::EACCES)
+        );
         fs::hard_link(&file, nested.join("hard.txt")).unwrap();
         std::os::unix::fs::symlink("file.txt", nested.join("link.txt")).unwrap();
         fs::create_dir_all(source.join("node_modules/pkg")).unwrap();
@@ -315,9 +358,25 @@ mod tests {
                 .unwrap()
                 .permissions()
                 .mode()
-                & 0o777,
-            0o640
+                & 0o7777,
+            0o6555
         );
+        let cloned_file = c_path(&destination.join("nested/file.txt")).unwrap();
+        let mut cloned_attribute = [0_u8; 9];
+        // SAFETY: the path and attribute are valid C strings, and the buffer
+        // pointer is valid for `cloned_attribute.len()` bytes.
+        let cloned_attribute_size = unsafe {
+            libc::getxattr(
+                cloned_file.as_ptr(),
+                attribute.as_ptr(),
+                cloned_attribute.as_mut_ptr().cast(),
+                cloned_attribute.len(),
+                0,
+                0,
+            )
+        };
+        assert_eq!(cloned_attribute_size, attribute_value.len() as isize);
+        assert_eq!(&cloned_attribute, attribute_value);
         assert_eq!(
             fs::metadata(destination.join("nested"))
                 .unwrap()

--- a/crates/core/src/strategy/apfs.rs
+++ b/crates/core/src/strategy/apfs.rs
@@ -58,7 +58,7 @@ fn clone_filtered_directory_apfs(from: &Path, to: &Path) -> Result<()> {
             } else {
                 clone_path_apfs(source, &destination)?;
             }
-            copy_metadata_apfs(source, &destination, MetadataTarget::FileOrDirectory)?;
+            copy_metadata_apfs(source, &destination, MetadataTarget::ClonedFile)?;
         } else if file_type.is_symlink() {
             std::os::unix::fs::symlink(fs::read_link(source)?, &destination)?;
             copy_metadata_apfs(source, &destination, MetadataTarget::Symlink)?;
@@ -67,9 +67,9 @@ fn clone_filtered_directory_apfs(from: &Path, to: &Path) -> Result<()> {
         }
     }
     for (source, destination) in directories.into_iter().rev() {
-        copy_metadata_apfs(&source, &destination, MetadataTarget::FileOrDirectory)?;
+        copy_metadata_apfs(&source, &destination, MetadataTarget::Directory)?;
     }
-    copy_metadata_apfs(from, to, MetadataTarget::FileOrDirectory)?;
+    copy_metadata_apfs(from, to, MetadataTarget::Directory)?;
     Ok(())
 }
 
@@ -96,7 +96,8 @@ fn clone_path_apfs(from: &Path, to: &Path) -> Result<()> {
 
 #[derive(Clone, Copy)]
 enum MetadataTarget {
-    FileOrDirectory,
+    ClonedFile,
+    Directory,
     Symlink,
 }
 
@@ -110,10 +111,14 @@ fn copy_metadata_apfs(from: &Path, to: &Path, target: MetadataTarget) -> Result<
     if unsafe { libc::lchown(destination.as_ptr(), metadata.uid(), metadata.gid()) } != 0 {
         return Err(std::io::Error::last_os_error().into());
     }
-    if matches!(target, MetadataTarget::FileOrDirectory) {
+    if !matches!(target, MetadataTarget::Symlink) {
         fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))?;
     }
-    copy_xattrs_apfs(from, to)?;
+    // clonefile already copied regular-file xattrs. Rewriting protected xattrs
+    // such as com.apple.provenance fails even when their values are unchanged.
+    if !matches!(target, MetadataTarget::ClonedFile) {
+        copy_xattrs_apfs(from, to)?;
+    }
     let times = [
         libc::timespec {
             tv_sec: metadata.atime(),


### PR DESCRIPTION
This PR was generated with Sol 5.6. I did my best to vet and challenge the agent, but OS semantics / Rust are not my strong points as a developer. I am happy to do any additional diligence you would like, and truly apologize if this is slop - it is difficult for me to judge quality here.

---

I have been trying to use Rift locally, and was running into "os error 13" when creating a new rift. If I passed `--copy-all`, the error would disappear. No other commands threw an error.

Since that isn't much to go on, I cloned Rift and had an agent add some debugging statements. It determined that the issue was from `com.apple.provenance` being reapplied to files, which isn't allowed. Directly from the LLM:

> Rift’s filtered APFS copy cloned each regular file, then redundantly reapplied its metadata. macOS rejected rewriting the protected com.apple.provenance xattr with EACCES, surfaced as OS error 13.

The commits in this PR address this. The first commit adds a test that fails under the current implementation; the second commit contains the fix.