### PR TITLE
fix: copy entries the caller cannot rewrite on APFS

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,6 +27,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("{0}")]
     Io(#[from] std::io::Error),
+    #[error("{operation} failed for {path}: {source}")]
+    IoAt {
+        operation: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("{0}")]
     Database(#[from] rusqlite::Error),
     #[error("{0}")]

--- a/crates/core/src/strategy/apfs.rs
+++ b/crates/core/src/strategy/apfs.rs
@@ -283,7 +283,50 @@ mod tests {
         fs::set_permissions(&nested, fs::Permissions::from_mode(0o710)).unwrap();
         let file = nested.join("file.txt");
         fs::write(&file, "hello").unwrap();
-        fs::set_permissions(&file, fs::Permissions::from_mode(0o640)).unwrap();
+        let file_path = c_path(&file).unwrap();
+        let attribute = std::ffi::CString::new("com.rift.test").unwrap();
+        let attribute_value = b"preserved";
+        // SAFETY: the path and attribute are valid C strings, and the value
+        // pointer is valid for `attribute_value.len()` bytes.
+        assert_eq!(
+            unsafe {
+                libc::setxattr(
+                    file_path.as_ptr(),
+                    attribute.as_ptr(),
+                    attribute_value.as_ptr().cast(),
+                    attribute_value.len(),
+                    0,
+                    0,
+                )
+            },
+            0
+        );
+        // The read-only mode makes a redundant xattr rewrite fail with EACCES,
+        // while the special bits verify clonefile's mode exception is repaired.
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o6555)).unwrap();
+        assert_eq!(
+            fs::metadata(&file).unwrap().permissions().mode() & 0o7777,
+            0o6555
+        );
+        // Confirm this fixture rejects the same setxattr operation the old
+        // metadata replay performed.
+        assert_eq!(
+            unsafe {
+                libc::setxattr(
+                    file_path.as_ptr(),
+                    attribute.as_ptr(),
+                    attribute_value.as_ptr().cast(),
+                    attribute_value.len(),
+                    0,
+                    libc::XATTR_NOFOLLOW,
+                )
+            },
+            -1
+        );
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::EACCES)
+        );
         fs::hard_link(&file, nested.join("hard.txt")).unwrap();
         std::os::unix::fs::symlink("file.txt", nested.join("link.txt")).unwrap();
         fs::create_dir_all(source.join("node_modules/pkg")).unwrap();
@@ -315,9 +358,25 @@ mod tests {
                 .unwrap()
                 .permissions()
                 .mode()
-                & 0o777,
-            0o640
+                & 0o7777,
+            0o6555
         );
+        let cloned_file = c_path(&destination.join("nested/file.txt")).unwrap();
+        let mut cloned_attribute = [0_u8; 9];
+        // SAFETY: the path and attribute are valid C strings, and the buffer
+        // pointer is valid for `cloned_attribute.len()` bytes.
+        let cloned_attribute_size = unsafe {
+            libc::getxattr(
+                cloned_file.as_ptr(),
+                attribute.as_ptr(),
+                cloned_attribute.as_mut_ptr().cast(),
+                cloned_attribute.len(),
+                0,
+                0,
+            )
+        };
+        assert_eq!(cloned_attribute_size, attribute_value.len() as isize);
+        assert_eq!(&cloned_attribute, attribute_value);
         assert_eq!(
             fs::metadata(destination.join("nested"))
                 .unwrap()

--- a/crates/core/src/strategy/apfs.rs
+++ b/crates/core/src/strategy/apfs.rs
@@ -58,7 +58,7 @@ fn clone_filtered_directory_apfs(from: &Path, to: &Path) -> Result<()> {
             } else {
                 clone_path_apfs(source, &destination)?;
             }
-            copy_metadata_apfs(source, &destination, MetadataTarget::FileOrDirectory)?;
+            copy_metadata_apfs(source, &destination, MetadataTarget::ClonedFile)?;
         } else if file_type.is_symlink() {
             std::os::unix::fs::symlink(fs::read_link(source)?, &destination)?;
             copy_metadata_apfs(source, &destination, MetadataTarget::Symlink)?;
@@ -67,9 +67,9 @@ fn clone_filtered_directory_apfs(from: &Path, to: &Path) -> Result<()> {
         }
     }
     for (source, destination) in directories.into_iter().rev() {
-        copy_metadata_apfs(&source, &destination, MetadataTarget::FileOrDirectory)?;
+        copy_metadata_apfs(&source, &destination, MetadataTarget::Directory)?;
     }
-    copy_metadata_apfs(from, to, MetadataTarget::FileOrDirectory)?;
+    copy_metadata_apfs(from, to, MetadataTarget::Directory)?;
     Ok(())
 }
 
@@ -96,7 +96,8 @@ fn clone_path_apfs(from: &Path, to: &Path) -> Result<()> {
 
 #[derive(Clone, Copy)]
 enum MetadataTarget {
-    FileOrDirectory,
+    ClonedFile,
+    Directory,
     Symlink,
 }
 
@@ -110,10 +111,14 @@ fn copy_metadata_apfs(from: &Path, to: &Path, target: MetadataTarget) -> Result<
     if unsafe { libc::lchown(destination.as_ptr(), metadata.uid(), metadata.gid()) } != 0 {
         return Err(std::io::Error::last_os_error().into());
     }
-    if matches!(target, MetadataTarget::FileOrDirectory) {
+    if !matches!(target, MetadataTarget::Symlink) {
         fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))?;
     }
-    copy_xattrs_apfs(from, to)?;
+    // clonefile already copied regular-file xattrs. Rewriting protected xattrs
+    // such as com.apple.provenance fails even when their values are unchanged.
+    if !matches!(target, MetadataTarget::ClonedFile) {
+        copy_xattrs_apfs(from, to)?;
+    }
     let times = [
         libc::timespec {
             tv_sec: metadata.atime(),

--- a/crates/core/src/strategy/apfs.rs
+++ b/crates/core/src/strategy/apfs.rs
@@ -104,20 +104,39 @@ enum MetadataTarget {
 fn copy_metadata_apfs(from: &Path, to: &Path, target: MetadataTarget) -> Result<()> {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
-    let metadata = fs::symlink_metadata(from)?;
+    let metadata = fs::symlink_metadata(from).map_err(io_at("read metadata", from))?;
     let destination = c_path(to)?;
+
+    // `clonefile` reproduces ownership, timestamps, and extended attributes, so
+    // a cloned entry only needs its mode reapplied: the syscall drops setuid and
+    // setgid. Replaying the rest is redundant, and it fails outright on entries
+    // the caller cannot rewrite.
+    if matches!(target, MetadataTarget::ClonedFile) {
+        return fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))
+            .map_err(io_at("set permissions", to));
+    }
+
+    // Ownership is preserved on a best-effort basis. Only a privileged caller
+    // can assign a uid it does not own or a gid it does not belong to, and a
+    // copy owned by the caller is still a correct copy.
     // SAFETY: `destination` is a valid null-terminated path, and uid/gid come
     // from filesystem metadata for `from`.
     if unsafe { libc::lchown(destination.as_ptr(), metadata.uid(), metadata.gid()) } != 0 {
-        return Err(std::io::Error::last_os_error().into());
+        let error = std::io::Error::last_os_error();
+        if !matches!(
+            error.raw_os_error(),
+            Some(libc::EPERM) | Some(libc::EACCES) | Some(libc::EINVAL)
+        ) {
+            return Err(io_at("change ownership", to)(error));
+        }
     }
+    // Extended attributes must be copied before the mode is applied. `setxattr`
+    // requires write access, so a read-only entry would otherwise lock its own
+    // copy.
+    copy_xattrs_apfs(from, to)?;
     if !matches!(target, MetadataTarget::Symlink) {
-        fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))?;
-    }
-    // clonefile already copied regular-file xattrs. Rewriting protected xattrs
-    // such as com.apple.provenance fails even when their values are unchanged.
-    if !matches!(target, MetadataTarget::ClonedFile) {
-        copy_xattrs_apfs(from, to)?;
+        fs::set_permissions(to, fs::Permissions::from_mode(metadata.mode()))
+            .map_err(io_at("set permissions", to))?;
     }
     let times = [
         libc::timespec {
@@ -140,7 +159,7 @@ fn copy_metadata_apfs(from: &Path, to: &Path, target: MetadataTarget) -> Result<
         )
     } != 0
     {
-        return Err(std::io::Error::last_os_error().into());
+        return Err(io_at("set timestamps", to)(std::io::Error::last_os_error()));
     }
     Ok(())
 }
@@ -227,6 +246,15 @@ fn copy_xattrs_apfs(from: &Path, to: &Path) -> Result<()> {
     Ok(())
 }
 
+fn io_at(operation: &'static str, path: &Path) -> impl FnOnce(std::io::Error) -> Error + use<> {
+    let path = path.to_path_buf();
+    move |source| Error::IoAt {
+        operation,
+        path,
+        source,
+    }
+}
+
 fn c_path(path: &Path) -> Result<std::ffi::CString> {
     use std::os::unix::ffi::OsStrExt;
 
@@ -274,6 +302,170 @@ mod tests {
                     .is_ok()
             );
         }
+    }
+
+    fn nix_groups() -> Vec<u32> {
+        let mut groups = vec![0_u32; 64];
+        // SAFETY: the buffer is sized by `groups.len()` and valid for writes.
+        let count = unsafe { libc::getgroups(groups.len() as i32, groups.as_mut_ptr()) };
+        if count < 0 {
+            return Vec::new();
+        }
+        groups.truncate(count as usize);
+        groups
+    }
+
+    fn read_xattr(path: &Path, name: &str) -> Option<Vec<u8>> {
+        let path = c_path(path).unwrap();
+        let name = std::ffi::CString::new(name).unwrap();
+        // SAFETY: both C strings are live, and a null buffer asks for the size.
+        let size = unsafe {
+            libc::getxattr(
+                path.as_ptr(),
+                name.as_ptr(),
+                std::ptr::null_mut(),
+                0,
+                0,
+                libc::XATTR_NOFOLLOW,
+            )
+        };
+        if size < 0 {
+            return None;
+        }
+        let mut value = vec![0_u8; size as usize];
+        // SAFETY: `value` is sized by the probe above and valid for writes.
+        let read = unsafe {
+            libc::getxattr(
+                path.as_ptr(),
+                name.as_ptr(),
+                value.as_mut_ptr().cast(),
+                value.len(),
+                0,
+                libc::XATTR_NOFOLLOW,
+            )
+        };
+        if read < 0 { None } else { Some(value) }
+    }
+
+    fn write_xattr(path: &Path, name: &str, value: &[u8]) {
+        let path = c_path(path).unwrap();
+        let name = std::ffi::CString::new(name).unwrap();
+        // SAFETY: all three pointers are live for the duration of the call.
+        let result = unsafe {
+            libc::setxattr(
+                path.as_ptr(),
+                name.as_ptr(),
+                value.as_ptr().cast(),
+                value.len(),
+                0,
+                libc::XATTR_NOFOLLOW,
+            )
+        };
+        assert_eq!(result, 0, "failed to seed an extended attribute");
+    }
+
+    /// Regression: Git object files are `0444`, and every file on recent macOS
+    /// carries `com.apple.provenance`. Applying the mode before the extended
+    /// attributes made `setxattr` fail with `EACCES`, so `rift create` could not
+    /// copy any Git repository.
+    #[test]
+    fn filtered_strategy_copies_read_only_files() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        let objects = source.join(".git/objects/0d");
+        fs::create_dir_all(&objects).unwrap();
+        let object = objects.join("8a474f");
+        fs::write(&object, "object").unwrap();
+        write_xattr(&object, "user.rift", b"marked");
+        fs::set_permissions(&object, fs::Permissions::from_mode(0o444)).unwrap();
+
+        ApfsStrategy
+            .copy_directory(&source, &destination, CopyMode::Filtered)
+            .unwrap();
+
+        let copied = destination.join(".git/objects/0d/8a474f");
+        assert_eq!(fs::read_to_string(&copied).unwrap(), "object");
+        assert_eq!(
+            fs::metadata(&copied).unwrap().permissions().mode() & 0o777,
+            0o444
+        );
+        assert_eq!(
+            read_xattr(&copied, "user.rift").as_deref(),
+            Some(&b"marked"[..])
+        );
+    }
+
+    /// Regression: a source file may belong to a group the caller is not a
+    /// member of, such as `wheel`. An unprivileged `lchown` then fails with
+    /// `EPERM`, which must not abort the copy: preserving ownership is a
+    /// privileged operation, and a copy owned by the caller is still correct.
+    #[test]
+    fn filtered_strategy_copies_entries_owned_by_another_group() {
+        // `/private/tmp` belongs to `wheel`, and a new entry inherits its
+        // parent's group, so this yields a source the caller does not share a
+        // group with — without needing privilege to set it up.
+        let Ok(source_root) = TempDir::new_in("/private/tmp") else {
+            return;
+        };
+        let source = source_root.path().join("source");
+        let nested = source.join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("file.txt"), "hello").unwrap();
+
+        let foreign = fs::metadata(&nested).unwrap().gid();
+        if nix_groups().contains(&foreign) {
+            // The caller shares the group after all; nothing to prove.
+            assert!(
+                std::env::var_os("RIFT_REQUIRE_APFS_TESTS").is_none(),
+                "the environment cannot produce an entry owned by a foreign group"
+            );
+            return;
+        }
+
+        // The destination inherits a different group, so reproducing the source
+        // group here is the privileged operation that must not be fatal.
+        let destination_root = TempDir::new().unwrap();
+        let destination = destination_root.path().join("destination");
+        ApfsStrategy
+            .copy_directory(&source, &destination, CopyMode::Filtered)
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination.join("nested/file.txt")).unwrap(),
+            "hello"
+        );
+    }
+
+    /// Regression: a directory that the owner cannot write must still receive
+    /// its extended attributes, which requires copying them before the mode.
+    #[test]
+    fn filtered_strategy_copies_read_only_directories() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        let locked = source.join("locked");
+        fs::create_dir_all(&locked).unwrap();
+        fs::write(locked.join("file.txt"), "hello").unwrap();
+        write_xattr(&locked, "user.rift", b"dir");
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = ApfsStrategy.copy_directory(&source, &destination, CopyMode::Filtered);
+
+        // Restore write access so the temporary directory can be cleaned up.
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+        result.unwrap();
+
+        let copied = destination.join("locked");
+        assert_eq!(
+            fs::metadata(&copied).unwrap().permissions().mode() & 0o777,
+            0o555
+        );
+        assert_eq!(
+            read_xattr(&copied, "user.rift").as_deref(),
+            Some(&b"dir"[..])
+        );
+        fs::set_permissions(&copied, fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     #[test]

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -74,6 +74,7 @@ impl From<Error> for Failure {
     fn from(error: Error) -> Self {
         let (code, path) = match &error {
             Error::Io(_) => ("io", None),
+            Error::IoAt { path, .. } => ("io", Some(path.clone())),
             Error::Database(_) => ("database", None),
             Error::Walk(_) => ("walk", None),
             Error::Path(_) => ("invalid_path", None),


### PR DESCRIPTION
> AI generated

Builds on **#20 by @IanMitchell**, whose two commits are included here unchanged. That diagnosis is correct: `clonefile` already copies extended attributes, and replaying them is what produced `Permission denied (os error 13)`.

This adds the two entry kinds that fix does not reach, plus one further failure with a different errno. Merging #20 first is fine — this then reduces to the third commit.

## 1. Read-only directories still fail

#20 skips the attribute replay for cloned files. Directories are created fresh, so they still replay metadata, and that replay applies the mode before the attributes. `setxattr` needs write access, so a `0555` directory locks its own copy.

Verified by running the new `filtered_strategy_copies_read_only_directories` test against #20's branch:

```
test filtered_strategy_copies_read_only_directories ... FAILED
called `Result::unwrap()` on an `Err` value:
  Io(Os { code: 13, kind: PermissionDenied, message: "Permission denied" })
```

Fix: copy the attributes before applying the mode.

## 2. A source owned by a foreign group aborts the copy

Separate bug, different errno, still fatal. `copy_metadata_apfs` treats `lchown` as required. Only a privileged caller can assign a gid it does not belong to, so one `wheel`-owned file anywhere in the tree kills the run:

```
Operation not permitted (os error 1)
```

This is not exotic — a real monorepo here had two such files, and the copy failed on the first one. Preserving ownership is inherently privileged; `cp` treats it as best-effort. Fix: tolerate `EPERM`/`EACCES`/`EINVAL` from `lchown`. A copy owned by the caller is still a correct copy.

## 3. Cloned entries reapply only the mode

`clonefile` reproduces ownership, timestamps, and extended attributes, so the rest of the replay is redundant. It does drop setuid and setgid, which is what #20's `0o6555` fixture pins, so the mode is still reapplied. Hard links share the source inode and need nothing.

## Error context

Both failures above surfaced as a bare errno with no operation and no path, which is what made them hard to place. This adds `Error::IoAt { operation, path, source }` for this strategy:

```
set extended attribute failed for /path/to/dest/.git/objects/0d/8a474f: Permission denied (os error 13)
change ownership failed for /path/to/dest/projects/app/.local/visited.txt: Operation not permitted (os error 1)
```

The FFI layer maps it to the existing `io` code and now carries the path.

## Tests

Three regression tests, each verified to fail when only its own fix is reverted:

- `filtered_strategy_copies_read_only_files` (#20 covers this one)
- `filtered_strategy_copies_read_only_directories`
- `filtered_strategy_copies_entries_owned_by_another_group`

The third needs a source whose group the caller is not in. It builds the fixture under `/private/tmp`, which belongs to `wheel`, so a new entry inherits a foreign group with no privilege required. If the caller turns out to share that group it skips, and under `RIFT_REQUIRE_APFS_TESTS` it fails rather than skipping quietly.

Full workspace: 69 tests pass, `cargo fmt --check` clean, no new clippy warnings. Also verified end to end by copying a large real monorepo that reproduced both failures.