### PR TITLE
Add precreate and remove lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,13 @@ On btrfs, exact copies use writable subvolume snapshots and filtered copies use 
 
 When the workspace is a Git repository, the new workspace has detached `HEAD` and retains index and working-tree state.
 
-If the source contains `.rift.toml`, `rift create` runs configured postcreate hooks after the workspace is created, registered, and prepared. Use `--no-hooks` to skip them.
+If the source contains `.rift.toml`, `rift create` runs configured precreate hooks before copying and postcreate hooks after the workspace is created, registered, and prepared. Use `--no-hooks` to skip them.
 
 ```toml
 version = 1
+
+[[hooks.precreate]]
+run = "pnpm run check"
 
 [[hooks.postcreate]]
 run = "pnpm install --frozen-lockfile"
@@ -74,7 +77,7 @@ run = "pnpm install --frozen-lockfile"
 run = "pnpm run codegen"
 ```
 
-Postcreate commands run in the new workspace root. If a hook fails, the workspace remains registered and `rift create` exits with an error.
+Precreate commands run in the source workspace; postcreate commands run in the new workspace. A precreate failure prevents creation. If a postcreate hook fails, the workspace remains registered and `rift create` exits with an error.
 
 ### List And Ancestors
 
@@ -91,12 +94,23 @@ rift ancestors
 rift remove                         # trash the current created rift subtree
 rift remove -f ~/code/app           # unregister a source root
 rift remove --children ~/code/app   # trash descendants, preserve the selected workspace
+rift remove --no-hooks ~/code/app/task
 rift gc                             # physically delete trash and prune missing entries
 ```
 
 Removing a created rift moves its active subtree into adjacent `.trash` storage. `rift gc` deletes that storage later.
 
 Removing a source root requires `-f` in the CLI. The source directory remains on disk. Its `.rift` marker is removed. Existing registered descendants are moved into trash. Missing descendants are removed from the registry.
+
+`preremove` hooks run in the selected workspace before removal. `postremove` hooks run after removal, from the moved trash directory when the selected workspace was trashed and from the selected workspace when it was preserved. Use `--no-hooks` to skip remove hooks.
+
+```toml
+[[hooks.preremove]]
+run = "pnpm run cleanup"
+
+[[hooks.postremove]]
+run = "echo removed $RIFT_SOURCE"
+```
 
 ### Shell Integration
 
@@ -150,8 +164,8 @@ With Node's permission model, also pass `--allow-ffi`.
 ```ts
 init(options?: { at?: string; database?: string }): null
 create(options?: { from?: string; name?: string; into?: string; copyAll?: boolean; hooks?: boolean; database?: string }): string
-remove(options?: { at?: string; all?: false; database?: string }): void
-remove(options: { at?: string; all: true; database?: string }): string[]
+remove(options?: { at?: string; all?: false; hooks?: boolean; database?: string }): void
+remove(options: { at?: string; all: true; hooks?: boolean; database?: string }): string[]
 list(options?: { of?: string; database?: string }): string[]
 ancestors(options?: { of?: string; database?: string }): string[]
 gc(options?: { database?: string }): string[]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
-use rift::{CopyMode, Create, CreateOptions, HookMode, InitProgress, Manager};
+use rift::{CopyMode, Create, CreateOptions, HookMode, InitProgress, Manager, RemoveOptions};
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -107,6 +107,8 @@ enum Command {
         children: bool,
         #[arg(short = 'f', long)]
         force: bool,
+        #[arg(long)]
+        no_hooks: bool,
     },
     List {
         of: Option<PathBuf>,
@@ -239,11 +241,19 @@ fn run() -> Result<()> {
             at,
             children,
             force,
+            no_hooks,
         } => {
             let at = manager.workspace(at.unwrap_or(std::env::current_dir()?))?;
             let cwd = std::fs::canonicalize(std::env::current_dir()?)?;
             if children {
-                let removed = manager.remove_all(&at)?;
+                let removed = manager.remove_all_with_options(
+                    &at,
+                    RemoveOptions::default().hook_mode(if no_hooks {
+                        HookMode::Skip
+                    } else {
+                        HookMode::Run
+                    }),
+                )?;
                 for path in &removed {
                     if cli.shell_cwd {
                         eprintln!("removed {}", path.display());
@@ -267,7 +277,14 @@ fn run() -> Result<()> {
                 } else {
                     None
                 };
-                manager.remove(&at)?;
+                manager.remove_with_options(
+                    &at,
+                    RemoveOptions::default().hook_mode(if no_hooks {
+                        HookMode::Skip
+                    } else {
+                        HookMode::Run
+                    }),
+                )?;
                 if unregistering_root {
                     eprintln!("Unregistered  {}", at.display());
                 }
@@ -416,6 +433,16 @@ mod tests {
                 no_hooks: true,
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn remove_command_accepts_no_hooks() {
+        let cli = Cli::try_parse_from(["rift", "remove", "--no-hooks"]).unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Command::Remove { no_hooks: true, .. }
         ));
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default)]
 pub(crate) struct Config {
-    postcreate: Vec<Postcreate>,
+    precreate: Vec<Hook>,
+    postcreate: Vec<Hook>,
+    preremove: Vec<Hook>,
+    postremove: Vec<Hook>,
 }
 
 impl Config {
@@ -17,17 +20,29 @@ impl Config {
         parse(&path, &fs::read_to_string(&path)?)
     }
 
-    pub(crate) fn postcreate(&self) -> &[Postcreate] {
+    pub(crate) fn precreate(&self) -> &[Hook] {
+        &self.precreate
+    }
+
+    pub(crate) fn postcreate(&self) -> &[Hook] {
         &self.postcreate
+    }
+
+    pub(crate) fn preremove(&self) -> &[Hook] {
+        &self.preremove
+    }
+
+    pub(crate) fn postremove(&self) -> &[Hook] {
+        &self.postremove
     }
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Postcreate {
+pub(crate) struct Hook {
     run: String,
 }
 
-impl Postcreate {
+impl Hook {
     pub(crate) fn run(&self) -> &str {
         &self.run
     }
@@ -45,12 +60,18 @@ struct RawConfig {
 #[serde(deny_unknown_fields)]
 struct RawHooks {
     #[serde(default)]
-    postcreate: Vec<RawPostcreate>,
+    precreate: Vec<RawHook>,
+    #[serde(default)]
+    postcreate: Vec<RawHook>,
+    #[serde(default)]
+    preremove: Vec<RawHook>,
+    #[serde(default)]
+    postremove: Vec<RawHook>,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RawPostcreate {
+struct RawHook {
     run: String,
 }
 
@@ -63,19 +84,25 @@ fn parse(path: &Path, contents: &str) -> Result<Config> {
             format!("unsupported config version {}", raw.version),
         ));
     }
-    raw.hooks
-        .postcreate
-        .into_iter()
-        .map(|step| {
-            let run = step.run.trim().to_owned();
-            if run.is_empty() {
-                Err(invalid_config(path, "postcreate run cannot be empty"))
-            } else {
-                Ok(Postcreate { run })
-            }
-        })
-        .collect::<Result<Vec<_>>>()
-        .map(|postcreate| Config { postcreate })
+    let parse_hooks = |name: &str, steps: Vec<RawHook>| {
+        steps
+            .into_iter()
+            .map(|step| {
+                let run = step.run.trim().to_owned();
+                if run.is_empty() {
+                    Err(invalid_config(path, format!("{name} run cannot be empty")))
+                } else {
+                    Ok(Hook { run })
+                }
+            })
+            .collect::<Result<Vec<_>>>()
+    };
+    Ok(Config {
+        precreate: parse_hooks("precreate", raw.hooks.precreate)?,
+        postcreate: parse_hooks("postcreate", raw.hooks.postcreate)?,
+        preremove: parse_hooks("preremove", raw.hooks.preremove)?,
+        postremove: parse_hooks("postremove", raw.hooks.postremove)?,
+    })
 }
 
 fn invalid_config(path: &Path, message: impl Into<String>) -> Error {
@@ -109,10 +136,31 @@ run = "echo two"
             config
                 .postcreate()
                 .iter()
-                .map(Postcreate::run)
+                .map(Hook::run)
                 .collect::<Vec<_>>(),
             vec!["echo one", "echo two"]
         );
+    }
+
+    #[test]
+    fn parses_all_lifecycle_hooks() {
+        let config = parse(
+            Path::new(".rift.toml"),
+            r#"
+version = 1
+[[hooks.precreate]]
+run = "echo precreate"
+[[hooks.preremove]]
+run = "echo preremove"
+[[hooks.postremove]]
+run = "echo postremove"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.precreate()[0].run(), "echo precreate");
+        assert_eq!(config.preremove()[0].run(), "echo preremove");
+        assert_eq!(config.postremove()[0].run(), "echo postremove");
     }
 
     #[test]

--- a/crates/core/src/hook.rs
+++ b/crates/core/src/hook.rs
@@ -1,42 +1,61 @@
-use crate::config::Postcreate;
+use crate::config::Hook;
 use crate::id::RiftId;
 use crate::{Error, Result};
 use std::path::Path;
 use std::process::Command;
 
-pub(crate) fn run_postcreate(
-    steps: &[Postcreate],
+pub(crate) fn run(
+    name: &str,
+    steps: &[Hook],
+    current_dir: &Path,
     source: &Path,
     destination: &Path,
     id: &RiftId,
     parent_id: &RiftId,
 ) -> Result<()> {
-    steps
-        .iter()
-        .map(Postcreate::run)
-        .try_for_each(|command| run_step(command, source, destination, id, parent_id))
+    steps.iter().map(Hook::run).try_for_each(|command| {
+        run_step(
+            name,
+            command,
+            current_dir,
+            source,
+            destination,
+            id,
+            parent_id,
+        )
+    })
 }
 
 fn run_step(
+    name: &str,
     command: &str,
+    current_dir: &Path,
     source: &Path,
     destination: &Path,
     id: &RiftId,
     parent_id: &RiftId,
 ) -> Result<()> {
     let status = shell_command(command)
-        .current_dir(destination)
+        .current_dir(current_dir)
         .env("RIFT_SOURCE", source)
         .env("RIFT_DESTINATION", destination)
         .env("RIFT_ID", id.as_str())
         .env("RIFT_PARENT_ID", parent_id.as_str())
         .status()
-        .map_err(|error| hook_failed(destination, command, format!("failed to start: {error}")))?;
+        .map_err(|error| {
+            hook_failed(
+                name,
+                current_dir,
+                command,
+                format!("failed to start: {error}"),
+            )
+        })?;
     if status.success() {
         Ok(())
     } else {
         Err(hook_failed(
-            destination,
+            name,
+            current_dir,
             command,
             format!("exited with {status}"),
         ))
@@ -57,8 +76,9 @@ fn shell_command(command: &str) -> Command {
     shell
 }
 
-fn hook_failed(path: &Path, command: &str, message: String) -> Error {
+fn hook_failed(name: &str, path: &Path, command: &str, message: String) -> Error {
     Error::HookFailed {
+        hook: name.to_owned(),
         path: path.to_path_buf(),
         command: command.to_owned(),
         message,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,8 +59,9 @@ pub enum Error {
     InsideSource(PathBuf),
     #[error("invalid rift config at {path}: {message}")]
     InvalidConfig { path: PathBuf, message: String },
-    #[error("postcreate hook failed at {path}: `{command}` {message}")]
+    #[error("{hook} hook failed at {path}: `{command}` {message}")]
     HookFailed {
+        hook: String,
         path: PathBuf,
         command: String,
         message: String,
@@ -102,6 +103,18 @@ impl Create {
 pub struct CreateOptions {
     pub copy_mode: CopyMode,
     pub hook_mode: HookMode,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RemoveOptions {
+    pub hook_mode: HookMode,
+}
+
+impl RemoveOptions {
+    pub fn hook_mode(mut self, hook_mode: HookMode) -> Self {
+        self.hook_mode = hook_mode;
+        self
+    }
 }
 
 impl CreateOptions {
@@ -224,6 +237,16 @@ impl Manager {
             HookMode::Skip => config::Config::default(),
         };
 
+        hook::run(
+            "precreate",
+            config.precreate(),
+            &from,
+            &from,
+            &destination,
+            &id,
+            &source.id,
+        )?;
+
         if let Err(error) = self
             .strategy
             .copy_directory(&from, &destination, options.copy_mode)
@@ -250,7 +273,15 @@ impl Manager {
             let _ = self.strategy.remove_directory(&destination);
         }
         result?;
-        hook::run_postcreate(config.postcreate(), &from, &destination, &id, &source.id)?;
+        hook::run(
+            "postcreate",
+            config.postcreate(),
+            &destination,
+            &from,
+            &destination,
+            &id,
+            &source.id,
+        )?;
         Ok(destination)
     }
 
@@ -306,26 +337,98 @@ impl Manager {
     }
 
     pub fn remove(&mut self, at: impl AsRef<Path>) -> Result<()> {
+        self.remove_with_options(at, RemoveOptions::default())
+    }
+
+    pub fn remove_with_options(
+        &mut self,
+        at: impl AsRef<Path>,
+        options: RemoveOptions,
+    ) -> Result<()> {
         let record = self.workspace_at(at)?;
-        if record.parent_id.is_none() {
-            return self.unregister_root(&record);
-        }
         marker::verify(&record.path, &record.id)?;
+        let config = self.remove_config(&record.path, options)?;
+        let parent_id = record.parent_id.as_ref().unwrap_or(&record.id);
+        hook::run(
+            "preremove",
+            config.preremove(),
+            &record.path,
+            &record.path,
+            &record.path,
+            &record.id,
+            parent_id,
+        )?;
+        if record.parent_id.is_none() {
+            self.unregister_root(&record)?;
+            return hook::run(
+                "postremove",
+                config.postremove(),
+                &record.path,
+                &record.path,
+                &record.path,
+                &record.id,
+                parent_id,
+            );
+        }
         let rows = self
             .registry
             .subtree(&record.id, SubtreeScope::IncludingRoot)?;
         self.trash_rows(&rows)?;
-        Ok(())
+        let trashed = trash_path(&record.id, &record.path)?;
+        hook::run(
+            "postremove",
+            config.postremove(),
+            &trashed,
+            &record.path,
+            &trashed,
+            &record.id,
+            parent_id,
+        )
     }
 
     pub fn remove_all(&mut self, at: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
+        self.remove_all_with_options(at, RemoveOptions::default())
+    }
+
+    pub fn remove_all_with_options(
+        &mut self,
+        at: impl AsRef<Path>,
+        options: RemoveOptions,
+    ) -> Result<Vec<PathBuf>> {
         let record = self.workspace_at(at)?;
         marker::verify(&record.path, &record.id)?;
+        let config = self.remove_config(&record.path, options)?;
+        let parent_id = record.parent_id.as_ref().unwrap_or(&record.id);
+        hook::run(
+            "preremove",
+            config.preremove(),
+            &record.path,
+            &record.path,
+            &record.path,
+            &record.id,
+            parent_id,
+        )?;
         let rows = self
             .registry
             .subtree(&record.id, SubtreeScope::DescendantsOnly)?;
         self.trash_rows(&rows)?;
+        hook::run(
+            "postremove",
+            config.postremove(),
+            &record.path,
+            &record.path,
+            &record.path,
+            &record.id,
+            parent_id,
+        )?;
         Ok(rows.into_iter().map(|record| record.path).collect())
+    }
+
+    fn remove_config(&self, workspace: &Path, options: RemoveOptions) -> Result<config::Config> {
+        match options.hook_mode {
+            HookMode::Run => config::Config::load(workspace),
+            HookMode::Skip => Ok(config::Config::default()),
+        }
     }
 
     fn unregister_root(&mut self, record: &Record) -> Result<()> {

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -212,6 +212,66 @@ run = "echo second >> hook.log"
 }
 
 #[test]
+fn create_runs_precreate_before_copy_and_postcreate_after_copy() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    fs::write(
+        source.join(".rift.toml"),
+        r#"
+version = 1
+
+[[hooks.precreate]]
+run = "echo pre >> lifecycle.log"
+
+[[hooks.postcreate]]
+run = "echo post >> lifecycle.log"
+"#,
+    )
+    .unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+
+    let child = manager
+        .create(create_input(source.clone(), "lifecycle"))
+        .unwrap();
+
+    assert_eq!(
+        fs::read_to_string(source.join("lifecycle.log")).unwrap(),
+        "pre\n"
+    );
+    assert_eq!(
+        fs::read_to_string(child.join("lifecycle.log")).unwrap(),
+        "pre\npost\n"
+    );
+}
+
+#[test]
+fn precreate_failure_does_not_create_or_register_workspace() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    fs::write(
+        source.join(".rift.toml"),
+        "version = 1\n[[hooks.precreate]]\nrun = \"exit 7\"\n",
+    )
+    .unwrap();
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let expected = child_path(&source, "precreate-failure");
+
+    let error = manager
+        .create(create_input(source.clone(), "precreate-failure"))
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::HookFailed { hook, path, .. }
+            if hook == "precreate" && path == source
+    ));
+    assert!(!expected.exists());
+    assert!(manager.list(&source).unwrap().is_empty());
+}
+
+#[test]
 fn postcreate_failure_leaves_registered_workspace() {
     let temp = TempDir::new().unwrap();
     let source = source(&temp);
@@ -341,6 +401,62 @@ fn removal_rejects_marker_mismatch_and_existing_trash_target() {
         manager.remove(&child),
         Err(Error::AlreadyExists(_))
     ));
+}
+
+#[test]
+fn remove_runs_hooks_before_and_after_moving_workspace() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let child = manager
+        .create(Create::new(source).named("remove-hooks"))
+        .unwrap();
+    fs::write(
+        child.join(".rift.toml"),
+        r#"
+version = 1
+
+[[hooks.preremove]]
+run = "echo pre >> lifecycle.log"
+
+[[hooks.postremove]]
+run = "echo post >> lifecycle.log"
+"#,
+    )
+    .unwrap();
+    let trash = trash_path(&marker_id(&child), &child).unwrap();
+
+    manager.remove(&child).unwrap();
+
+    assert!(!child.exists());
+    assert_eq!(
+        fs::read_to_string(trash.join("lifecycle.log")).unwrap(),
+        "pre\npost\n"
+    );
+}
+
+#[test]
+fn preremove_failure_leaves_workspace_active() {
+    let temp = TempDir::new().unwrap();
+    let source = source(&temp);
+    let mut manager = manager(&temp);
+    manager.init(&source).unwrap();
+    let child = manager
+        .create(Create::new(source.clone()).named("remove-failure"))
+        .unwrap();
+    fs::write(
+        child.join(".rift.toml"),
+        "version = 1\n[[hooks.preremove]]\nrun = \"exit 9\"\n",
+    )
+    .unwrap();
+
+    assert!(matches!(
+        manager.remove(&child),
+        Err(Error::HookFailed { hook, .. }) if hook == "preremove"
+    ));
+    assert!(child.exists());
+    assert_eq!(manager.list(&source).unwrap(), vec![child]);
 }
 
 #[test]

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -1,4 +1,4 @@
-use rift::{CopyMode, Create, CreateOptions, Error, HookMode, Manager};
+use rift::{CopyMode, Create, CreateOptions, Error, HookMode, Manager, RemoveOptions};
 use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString, c_char};
 use std::path::PathBuf;
@@ -27,6 +27,7 @@ enum Command {
     Remove {
         at: PathBuf,
         all: Option<bool>,
+        hooks: Option<bool>,
     },
     List {
         of: PathBuf,
@@ -137,15 +138,20 @@ fn execute(input: &str) -> Result<Value, Failure> {
             )
             .map(|path| Value::Path(Some(path)))
             .map_err(Failure::from),
-        Command::Remove { at, all } => {
+        Command::Remove { at, all, hooks } => {
+            let options = RemoveOptions::default().hook_mode(if hooks.unwrap_or(true) {
+                HookMode::Run
+            } else {
+                HookMode::Skip
+            });
             if all.unwrap_or(false) {
                 manager
-                    .remove_all(at)
+                    .remove_all_with_options(at, options)
                     .map(Value::Paths)
                     .map_err(Failure::from)
             } else {
                 manager
-                    .remove(at)
+                    .remove_with_options(at, options)
                     .map(|()| Value::Empty(()))
                     .map_err(Failure::from)
             }
@@ -271,6 +277,28 @@ mod tests {
     }
 
     #[test]
+    fn remove_hooks_option_is_accepted_by_the_protocol() {
+        let request = serde_json::from_str::<Request>(
+            r#"{
+                "command": "remove",
+                "at": "/tmp/app",
+                "all": true,
+                "hooks": false
+            }"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            request.command,
+            Command::Remove {
+                all: Some(true),
+                hooks: Some(false),
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn hook_and_config_errors_are_exposed_with_codes_and_paths() {
         let config = serde_json::to_value(Response::Error {
             error: Error::InvalidConfig {
@@ -282,6 +310,7 @@ mod tests {
         .unwrap();
         let hook = serde_json::to_value(Response::Error {
             error: Error::HookFailed {
+                hook: "postcreate".into(),
                 path: PathBuf::from("/tmp/app"),
                 command: "exit 1".into(),
                 message: "exited with 1".into(),

--- a/npm/rift-snapshot/bun/index.js
+++ b/npm/rift-snapshot/bun/index.js
@@ -55,8 +55,8 @@ export function create({ from = process.cwd(), name, into, copyAll, hooks, datab
   return call({ command: "create", from, name, into, copyAll, hooks, database })
 }
 
-export function remove({ at = process.cwd(), all = false, database } = {}) {
-  const result = call({ command: "remove", at, all, database })
+export function remove({ at = process.cwd(), all = false, hooks, database } = {}) {
+  const result = call({ command: "remove", at, all, hooks, database })
   return all ? result : undefined
 }
 

--- a/npm/rift-snapshot/index.d.ts
+++ b/npm/rift-snapshot/index.d.ts
@@ -16,6 +16,7 @@ export interface CreateOptions extends Options {
 
 export interface RemoveOptions extends AtOptions {
   all?: boolean
+  hooks?: boolean
 }
 
 export interface OfOptions extends Options {

--- a/npm/rift-snapshot/node/index.js
+++ b/npm/rift-snapshot/node/index.js
@@ -48,8 +48,8 @@ export function create({ from = process.cwd(), name, into, copyAll, hooks, datab
   return call({ command: "create", from, name, into, copyAll, hooks, database })
 }
 
-export function remove({ at = process.cwd(), all = false, database } = {}) {
-  const result = call({ command: "remove", at, all, database })
+export function remove({ at = process.cwd(), all = false, hooks, database } = {}) {
+  const result = call({ command: "remove", at, all, hooks, database })
   return all ? result : undefined
 }
 

--- a/specs.md
+++ b/specs.md
@@ -46,22 +46,31 @@ Default behavior:
 - Copy the workspace while excluding known heavyweight regenerable dependency, build, and cache artifacts.
 - Preserve manifests, lockfiles, dirty files, staged files, untracked files, and ignored files that are not part of the built-in excluded artifact set.
 - `copyAll` opts into exact copying, including dependency and build artifacts.
-- `hooks` defaults to true and runs `.rift.toml` postcreate hooks after workspace creation, Git preparation, and registry insertion. `hooks: false` skips config loading and hook execution.
+- `hooks` defaults to true and runs `.rift.toml` precreate hooks before copying and postcreate hooks after workspace creation, Git preparation, and registry insertion. `hooks: false` skips config loading and hook execution.
 - Detach `HEAD` in the new workspace.
 - Return the path of the new workspace.
 
 Default excluded artifacts are matched at any depth and include `node_modules`, `.pnpm-store`, `.yarn/cache`, `.yarn/unplugged`, `.yarn/install-state.gz`, `.yarn/build-state.yml`, `target`, `.venv`, `venv`, `.tox`, `.nox`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.next`, `.nuxt`, `.svelte-kit`, `.turbo`, `.vite`, `.parcel-cache`, `.cache`, `dist`, `build`, and `coverage`.
 
-`.rift.toml` supports one v1 hook shape:
+`.rift.toml` supports four v1 lifecycle hooks with the same shape:
 
 ```toml
 version = 1
 
+[[hooks.precreate]]
+run = "pnpm run check"
+
 [[hooks.postcreate]]
 run = "pnpm install --frozen-lockfile"
+
+[[hooks.preremove]]
+run = "pnpm run cleanup"
+
+[[hooks.postremove]]
+run = "echo removed"
 ```
 
-Postcreate hooks run sequentially in the destination workspace with inherited stdio and environment plus `RIFT_SOURCE`, `RIFT_DESTINATION`, `RIFT_ID`, and `RIFT_PARENT_ID`. The first failing command stops later hooks. The created workspace remains registered and on disk, and the create operation reports a hook failure with the destination path.
+Hooks run sequentially with inherited stdio and environment plus `RIFT_SOURCE`, `RIFT_DESTINATION`, `RIFT_ID`, and `RIFT_PARENT_ID`. Precreate runs in the source workspace and postcreate runs in the destination. The first failing command stops later hooks. A precreate failure prevents copying; after a postcreate failure, the created workspace remains registered and on disk.
 
 On btrfs, `from` must already be a subvolume. If it is an ordinary directory, fail and instruct the user to run `rift init` first. On other reflink-capable Linux filesystems, clone the directory tree with native per-file reflinks.
 
@@ -88,6 +97,7 @@ Default storage is a hidden sibling directory of the original registered workspa
 remove(input: {
   at: AbsolutePath
   all?: boolean
+  hooks?: boolean
 }): void
 ```
 
@@ -98,6 +108,7 @@ remove(input: {
 - The CLI exposes the descendant-preserving mode as `rift remove --children`; the core and FFI input field remains `all`.
 - If `at` identifies a created rift, move its full descendant subtree into trash.
 - When `all` is true, preserve `at` and delete every managed descendant. In this mode `at` may be the registered source root.
+- `hooks` defaults to true. Preremove runs in `at` before filesystem or registry changes. Postremove runs after successful removal, from the trash directory when `at` was moved and from `at` when it was preserved. A preremove failure prevents removal; a postremove failure reports an error without rolling back the completed removal.
 - Resolve all descendants through `parent_id` and move their directories deepest-first.
 - Verify each existing directory's `.rift` marker before deleting it.
 - Refuse removal if any descendant path is missing, because the registered active tree no longer matches the filesystem.


### PR DESCRIPTION
Extends the existing `postcreate` hook system with three new lifecycle hooks:

- `precreate`: Runs in the source workspace before copying. Failure prevents workspace creation.
- `preremove`: Runs in the selected workspace before removal. Failure leaves the workspace active.
- `postremove`: Runs after successful removal, from the trash location when the workspace was moved or from the original workspace when it was preserved.
- `postcreate`: Existing behavior is preserved. Its implementation now uses the shared lifecycle-hook runner.

This also adds `rift remove --no-hooks`, exposes the remove `hooks` option through the Bun and Node bindings, and reports failures using the relevant hook name. Documentation and tests cover execution context, ordering, failure behavior, and hook-skipping options.